### PR TITLE
:wrench: config: 자동 리뷰어 설정을 위한 CODEOWNERS 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zxcv9203 @jiixon


### PR DESCRIPTION
## PR 설명
- [🔧 config: 자동 리뷰어 설정을 위한 CODEOWNERS 추가](https://github.com/local-talk/local-talk-BE/commit/1a4fb9b3fce61994b77e8e11c100d685cbf381d5)
  -  자동으로 리뷰어를 지정하기 위해 `CODEOWNERS` 파일을 추가했습니다.  
  - 모든 파일에 대해 리뷰어가 자동으로 지정됩니다.

## 작업 내용
- [x] `.github/CODEOWNERS` 파일 생성
- [x] 전체 경로(`/`)에 대한 코드 오너로 `@zxcv9203`, `@jiixon` 지정
- [x] GitHub CODEOWNERS 규칙에 맞춰 경로/계정명 설정

## 참고
- [GitHub Docs - CODEOWNERS](https://docs.github.com/ko/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- 어느정도 기본 설정은 한 것 같아서 이제부터는 PR 작성해서 진행하겠습니다
