### PR TITLE
:tada: init : 외부 API 요청을 위한 WebClient 모듈 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ out/
 ### Logs ###
 logs/
 *.log
+*CLAUDE*

--- a/apps/localtalk-api/build.gradle.kts
+++ b/apps/localtalk-api/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(project(":modules:jpa"))
     implementation(project(":modules:web"))
+    implementation(project(":modules:webclient"))
     implementation(project(":supports:logging"))
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/apps/localtalk-api/src/main/resources/application.yml
+++ b/apps/localtalk-api/src/main/resources/application.yml
@@ -20,12 +20,38 @@ spring:
   config:
     import:
       - jpa.yml
-logging:
-  level:
-    com:
-      zaxxer:
-        hikari: DEBUG
+      - webclient.yml
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID:}
+            client-secret: ${KAKAO_CLIENT_SECRET:}
+          apple:
+            client-id: ${APPLE_CLIENT_ID:}
 
+jwt:
+  secret: ${JWT_SECRET:defaultSecretKeyForDevelopmentOnlyNotForProduction}
+  access-token-expiry: 3600
+  refresh-token-expiry: 2592000
+
+# OAuth2 설정
+oauth2:
+  kakao:
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+  apple:
+    client-id: ${APPLE_CLIENT_ID:}
+    jwks-uri: https://appleid.apple.com/auth/keys
+
+webclient:
+  connect-timeout: 30s
+  response-timeout: 30s
+  read-timeout: 30s
+  write-timeout: 30s
+  max-in-memory-size: 10485760 # 10MB
+  max-connections: 500
+  pending-acquire-timeout: 60s
 ---
 spring:
   config:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,16 @@ logstash-logback-encoder = "8.0"
 mockk = "1.13.8"
 
 [libraries]
+# Logging
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback-encoder" }
+
+# Testing
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+# WebClient (외부 API 호출 전용)
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
+spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
+reactor-test = { module = "io.projectreactor:reactor-test" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/modules/webclient/README.md
+++ b/modules/webclient/README.md
@@ -1,0 +1,168 @@
+# WebClient 모듈
+
+외부 API 호출을 위한 공통 WebClient 설정 및 Bean 제공 모듈입니다.
+
+## 🎯 목적
+
+- **Spring MVC + WebClient 아키텍처**: 내부는 Spring MVC, 외부 호출만 WebClient 활용
+- **공통 설정 통합**: 타임아웃, 연결풀, 메모리 제한 등 외부 API 호출 공통 설정
+- **재사용성**: 다른 프로젝트에서도 그대로 사용 가능한 범용 WebClient 모듈
+
+## 📦 제공하는 기능
+
+### Auto Configuration
+- `WebClientConfig`: Spring Boot Auto Configuration으로 WebClient Bean 자동 등록
+- `WebClientProperties`: `@ConfigurationProperties`로 설정값 바인딩
+
+### 제공되는 Bean
+```kotlin
+@Bean
+fun webClientBuilder(): WebClient.Builder   
+
+@Bean  
+fun defaultWebClient(): WebClient        
+```
+
+### 설정 가능한 항목
+- **타임아웃 설정**: connect, response, read, write timeout
+- **메모리 제한**: 응답 메모리 사이즈 제한
+- **연결 관리**: 최대 연결 수, 대기 시간
+
+## 🚀 사용법
+
+### 1. 의존성 추가
+
+#### apps 프로젝트의 build.gradle.kts
+```kotlin
+dependencies {
+    implementation(project(":modules:webclient"))
+}
+```
+
+### 2. 설정 파일 import
+
+#### application.yml
+```yaml
+spring:
+  config:
+    import:
+      - webclient.yml
+```
+
+### 3. 설정값 커스터마이징 (선택사항)
+
+기본값을 오버라이드하려면 application.yml에 추가:
+
+```yaml
+client:
+  webclient:
+    connect-timeout: 10s        # 기본: 30s
+    response-timeout: 15s       # 기본: 30s  
+    read-timeout: 20s          # 기본: 30s
+    write-timeout: 10s         # 기본: 30s
+    max-in-memory-size: 5242880 # 5MB (기본: 10MB)
+    max-connections: 300       # 기본: 500
+    pending-acquire-timeout: 30s # 기본: 60s
+```
+
+### 4. 코드에서 사용
+
+#### 기본 WebClient 사용
+```kotlin
+@Service
+class ExternalApiService(
+    private val webClient: WebClient  // 자동 주입
+) {
+    suspend fun callKakaoApi(): String {
+        return webClient
+            .get()
+            .uri("https://kapi.kakao.com/v2/user/me")
+            .header("Authorization", "Bearer $accessToken")
+            .retrieve()
+            .bodyToMono<String>()
+            .awaitSingle()
+    }
+}
+```
+
+#### 커스텀 WebClient 생성
+```kotlin
+@Service  
+class AppleApiService(
+    private val webClientBuilder: WebClient.Builder
+) {
+    private val appleWebClient = webClientBuilder
+        .baseUrl("https://appleid.apple.com")
+        .defaultHeader("Content-Type", "application/json")
+        .build()
+        
+    suspend fun validateToken(identityToken: String): AppleTokenInfo {
+        return appleWebClient
+            .post()
+            .uri("/auth/token")
+            .bodyValue(mapOf("id_token" to identityToken))
+            .retrieve()
+            .bodyToMono<AppleTokenInfo>()
+            .awaitSingle()
+    }
+}
+```
+
+## ⚙️ 기본 설정값
+
+```yaml
+client:
+  webclient:
+    connect-timeout: 30s        # 연결 타임아웃
+    response-timeout: 30s       # 응답 타임아웃  
+    read-timeout: 30s          # 읽기 타임아웃
+    write-timeout: 30s         # 쓰기 타임아웃
+    max-in-memory-size: 10485760 # 10MB 응답 크기 제한
+    max-connections: 500       # 최대 연결 수
+    pending-acquire-timeout: 60s # 연결 대기 시간
+```
+
+## 🏗️ 내부 구조
+
+```
+modules/webclient/
+├── src/main/kotlin/com/localtalk/webclient/
+│   └── config/
+│       ├── WebClientConfig.kt           # Auto Configuration
+│       └── WebClientProperties.kt       # Configuration Properties
+├── src/main/resources/
+│   └── webclient.yml                   # 기본 설정
+└── build.gradle.kts                    # 모듈 의존성
+```
+
+### 핵심 클래스
+
+#### WebClientConfig
+```kotlin
+@Configuration
+@EnableConfigurationProperties(WebClientProperties::class)
+class WebClientConfig(private val properties: WebClientProperties) {
+    // WebClient Bean 생성 및 설정 적용
+}
+```
+
+#### WebClientProperties  
+```kotlin
+@ConfigurationProperties(prefix = "client.webclient")
+data class WebClientProperties(
+    val connectTimeout: Duration = Duration.ofSeconds(30),
+    // ... 기타 설정
+)
+```
+
+## 🚫 주의사항
+
+### 이 모듈은 제공하지 않음
+- ❌ 구체적인 API 호출 로직 (OAuth2 토큰 교환, 사용자 정보 조회 등)
+- ❌ 특정 서비스에 종속적인 설정 (Kakao, Apple 등)
+- ❌ 비즈니스 로직 구현
+
+### 올바른 사용법
+- ✅ 외부 API 호출 시에만 사용 (OAuth2 provider, 3rd party API)
+- ✅ 내부 서비스 간 통신은 일반적인 Spring MVC 방식 사용
+- ✅ Coroutine/suspend function과 함께 사용하여 성능 최적화

--- a/modules/webclient/build.gradle.kts
+++ b/modules/webclient/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    api(libs.spring.boot.starter.webflux)
+    api(libs.spring.boot.configuration.processor)
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.reactor.test)
+}

--- a/modules/webclient/src/main/kotlin/com/localtalk/webclient/config/WebClientConfig.kt
+++ b/modules/webclient/src/main/kotlin/com/localtalk/webclient/config/WebClientConfig.kt
@@ -1,0 +1,46 @@
+package com.localtalk.webclient
+
+import com.localtalk.webclient.config.WebClientProperties
+import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.handler.timeout.WriteTimeoutHandler
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.util.concurrent.TimeUnit
+
+@Configuration
+@EnableConfigurationProperties(WebClientProperties::class)
+class WebClientConfig(
+    private val properties: WebClientProperties,
+) {
+
+    @Bean
+    fun webClientBuilder(): WebClient.Builder {
+        val httpClient = createHttpClient()
+
+        return WebClient.builder()
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .codecs { configurer ->
+                configurer.defaultCodecs().maxInMemorySize(properties.maxInMemorySize)
+            }
+    }
+
+    @Bean
+    fun defaultWebClient(webClientBuilder: WebClient.Builder): WebClient {
+        return webClientBuilder.build()
+    }
+
+    private fun createHttpClient(): HttpClient {
+        return HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.connectTimeout.toMillis().toInt())
+            .responseTimeout(properties.responseTimeout)
+            .doOnConnected { conn ->
+                conn.addHandlerLast(ReadTimeoutHandler(properties.readTimeout.toSeconds(), TimeUnit.SECONDS))
+                    .addHandlerLast(WriteTimeoutHandler(properties.writeTimeout.toSeconds(), TimeUnit.SECONDS))
+            }
+    }
+}

--- a/modules/webclient/src/main/kotlin/com/localtalk/webclient/config/WebClientProperties.kt
+++ b/modules/webclient/src/main/kotlin/com/localtalk/webclient/config/WebClientProperties.kt
@@ -1,0 +1,15 @@
+package com.localtalk.webclient.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "client.webclient")
+data class WebClientProperties(
+    val connectTimeout: Duration = Duration.ofSeconds(30),
+    val responseTimeout: Duration = Duration.ofSeconds(30),
+    val readTimeout: Duration = Duration.ofSeconds(30),
+    val writeTimeout: Duration = Duration.ofSeconds(30),
+    val maxInMemorySize: Int = 1024 * 1024 * 10, // 10MB
+    val maxConnections: Int = 500,
+    val pendingAcquireTimeout: Duration = Duration.ofSeconds(60),
+)

--- a/modules/webclient/src/main/resources/webclient.yml
+++ b/modules/webclient/src/main/resources/webclient.yml
@@ -1,0 +1,9 @@
+client:
+  webclient:
+    connect-timeout: 30s
+    response-timeout: 30s
+    read-timeout: 30s
+    write-timeout: 30s
+    max-in-memory-size: 10485760 # 10MB
+    max-connections: 500
+    pending-acquire-timeout: 60s

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,5 @@ rootProject.name = "local-talk-BE"
 include("apps:localtalk-api")
 include("modules:jpa")
 include("modules:web")
+include("modules:webclient")
 include("supports:logging")


### PR DESCRIPTION
## PR 설명
- [🎉 init : 외부 API 요청을 위한 WebClient 모듈 추가](https://github.com/local-talk/local-talk-BE/commit/81a95911f7658c23eeedc01b53c0d25679f12556)
  - 외부 API 호출 시 재사용 가능한 공통 WebClient 설정 모듈을 신규 추가했습니다.
  - WebClient의 타임아웃·메모리 제한·연결 풀 등 공통 설정을 제공합니다.
  - 내부 서비스 간 통신은 Spring MVC를 유지하고, 외부 API 호출에만 WebClient를 사용합니다. 

## 작업 내용
- [x] modules:webclient 모듈 신규 생성
- [x] 기본 WebClient와 추가 커스텀 할 수 있도록 WebClient.Builder Bean 등록
- [x] 기본 설정 파일(webclient.yml) 추가 및 기본값 정의
- [x] WebClient 타임아웃 및 응답 제한 설정
- [x] README 작성 (사용법, 주의사항 포함)
