### PR TITLE
Feat/jpa module test fixture

### DIFF
--- a/apps/localtalk-api/build.gradle.kts
+++ b/apps/localtalk-api/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:mysql")
+
+    testImplementation(testFixtures(project(":modules:jpa")))
 }

--- a/modules/jpa/README.md
+++ b/modules/jpa/README.md
@@ -1,0 +1,291 @@
+# JPA 모듈
+
+Spring Boot JPA 애플리케이션을 위한 데이터베이스 연결과 공통 엔티티 기능 모듈입니다.
+
+MySQL 연결 설정, 공통 엔티티 클래스, 그리고 테스트 인프라를 제공합니다.
+
+## 이게 뭔가요?
+
+이 모듈을 추가하면:
+
+- 🗄️ **HikariCP** 기반 고성능 MySQL 연결 풀 설정
+- 📅 **BaseEntity** - 자동 audit 필드와 soft delete 기능
+- 🧪 **testFixtures** - MySQL TestContainer와 데이터베이스 정리 유틸리티
+- ⚡ **JPA 최적화** - 배치 처리와 UTC 시간대 설정
+
+## 어떻게 쓰나요?
+
+### 1. 모듈 추가
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":modules:jpa"))
+}
+```
+
+### 2. Entity 클래스 만들기
+
+```kotlin
+import com.localtalk.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "member")
+class Member(
+    @Column(name = "name", nullable = false)
+    val name: String,
+    
+    @Column(name = "email", nullable = false)
+    val email: String,
+) : BaseEntity() {
+
+    // 비즈니스 로직이나 validation을 추가하려면
+    override fun validate() {
+        require(email.contains("@")) { "유효하지 않은 이메일 형식입니다" }
+    }
+}
+```
+
+### 3. Repository 만들기
+
+```kotlin
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository : JpaRepository<Member, Long>
+```
+
+### 4. 테스트 작성하기
+
+```kotlin
+import com.localtalk.config.MysqlTestContainerConfig
+import com.localtalk.utils.JpaDatabaseCleaner
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(MysqlTestContainerConfig::class)
+class MemberRepositoryTest(
+    @Autowired private val memberRepository: MemberRepository,
+    @Autowired private val jpaDatabaseCleaner: JpaDatabaseCleaner,
+) {
+
+    @AfterEach
+    fun cleanup() {
+        jpaDatabaseCleaner.truncateAllTables()
+    }
+
+    @Test
+    fun `회원을 저장하고 조회할 수 있다`() {
+        // given
+        val member = Member(name = "홍길동", email = "hong@example.com")
+        
+        // when
+        val savedMember = memberRepository.save(member)
+        
+        // then
+        assertThat(savedMember.id).isGreaterThan(0L)
+        assertThat(savedMember.createdAt).isNotNull()
+        assertThat(savedMember.updatedAt).isNotNull()
+    }
+}
+```
+
+## 자동으로 뭐가 되나요?
+
+### 1. BaseEntity 자동 기능
+
+모든 엔티티에 자동으로 추가되는 필드들:
+
+```sql
+CREATE TABLE member (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL,    -- 자동 생성 📅
+    updated_at DATETIME(6) NOT NULL,    -- 자동 업데이트 📅
+    deleted_at DATETIME(6) NULL         -- Soft Delete 🗑️
+);
+```
+
+### 2. Soft Delete 기능
+
+```kotlin
+// 데이터를 실제로 삭제하지 않고 deleted_at만 설정
+member.delete()  // deleted_at = 현재시간
+
+// 삭제 취소
+member.restore()  // deleted_at = null
+```
+
+### 3. 자동 Validation
+
+```kotlin
+@Entity
+class Member : BaseEntity() {
+    override fun validate() {
+        require(name.isNotBlank()) { "이름은 필수입니다" }
+        require(email.contains("@")) { "올바른 이메일 형식이 아닙니다" }
+    }
+}
+
+// 저장할 때마다 자동으로 validate() 실행
+memberRepository.save(member)  // validate() 호출됨
+```
+
+## 테스트 인프라 (testFixtures)
+
+### 다른 모듈에서 testFixtures 사용하기
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    testImplementation(testFixtures(project(":modules:jpa")))
+}
+```
+
+### MysqlTestContainerConfig
+
+자동으로 MySQL TestContainer를 시작하고 설정합니다:
+
+```kotlin
+@SpringBootTest
+@Import(MysqlTestContainerConfig::class)  // 이것만 추가하면 끝!
+class MyIntegrationTest {
+    // 실제 MySQL 8.0이 Docker로 자동 시작됩니다
+    // UTF8MB4 인코딩으로 설정됩니다
+}
+```
+
+### JpaDatabaseCleaner
+
+테스트 간 데이터 정리를 자동화합니다:
+
+```kotlin
+@AfterEach
+fun cleanup() {
+    jpaDatabaseCleaner.truncateAllTables()
+}
+```
+
+- 모든 테이블을 자동 탐지해서 TRUNCATE
+- FOREIGN KEY 제약 조건 안전하게 처리
+- 테스트 격리 보장
+
+## 데이터베이스 설정
+
+### 기본 설정 (`jpa.yml`)
+
+```yaml
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none  # 운영환경에서는 none
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100    # N+1 문제 방지
+        timezone.default_storage: NORMALIZE_UTC  # UTC 저장
+        jdbc.time_zone: UTC              # 시간대 통일
+
+datasource:
+  hikari:
+    master:
+      maximum-pool-size: 40              # 커넥션 풀 크기
+      minimum-idle: 30
+      connection-timeout: 3000           # 3초 타임아웃
+```
+
+### 환경별 설정
+
+#### Local/Test 환경
+```yaml
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create      # 테이블 자동 생성
+    show-sql: true          # SQL 로그 출력
+```
+
+#### Production 환경
+```yaml
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none        # 수동 마이그레이션만
+    show-sql: false         # SQL 로그 끄기
+```
+
+## 모듈 구조
+
+```
+modules/jpa/
+├── src/main/kotlin/com/localtalk/
+│   ├── config/
+│   │   └── DataSourceConfig.kt           # HikariCP 설정
+│   ├── domain/
+│   │   └── BaseEntity.kt                 # 공통 엔티티 기능
+│   └── resources/
+│       └── jpa.yml                       # JPA 설정 파일
+├── src/testFixtures/kotlin/com/localtalk/
+│   ├── config/
+│   │   └── MysqlTestContainerConfig.kt   # TestContainer 설정
+│   └── utils/
+│       └── JpaDatabaseCleaner.kt         # 테스트 데이터 정리
+└── build.gradle.kts                      # testFixtures 플러그인
+```
+
+## 설정 변경이 필요하다면
+
+### 커넥션 풀 크기 조정
+
+```yaml
+# application.yml
+datasource:
+  hikari:
+    master:
+      maximum-pool-size: 20   # 기본값 40
+      minimum-idle: 10        # 기본값 30
+```
+
+### Hibernate SQL 로깅 켜기
+
+```yaml
+# application.yml
+spring:
+  jpa:
+    show-sql: true
+    
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+```
+
+### testFixtures 없이 사용하기
+
+testFixtures 의존성을 추가하지 않으면 테스트 유틸리티 없이도 JPA 모듈을 사용할 수 있습니다:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":modules:jpa"))
+    // testImplementation(testFixtures(project(":modules:jpa")))  # 생략 가능
+}
+```
+
+## 트러블슈팅
+
+### Q. "Table doesn't exist" 오류가 발생해요
+A. `spring.jpa.hibernate.ddl-auto` 설정을 확인하세요. `test` 프로파일에서는 `create`로 설정되어야 합니다.
+
+### Q. 시간대 관련 오류가 발생해요
+A. 모든 시간은 UTC로 저장됩니다. 애플리케이션에서 시간대 변환을 처리해주세요.
+
+### Q. N+1 문제가 발생해요
+A. `@BatchSize`나 `@EntityGraph`를 사용하거나, `default_batch_fetch_size: 100` 설정을 활용하세요.
+
+### Q. testFixtures가 동작하지 않아요
+A. Docker가 실행 중인지 확인하고, `@ActiveProfiles("test")`가 설정되어 있는지 확인하세요.

--- a/modules/jpa/build.gradle.kts
+++ b/modules/jpa/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    api("org.springframework.boot:spring-boot-starter-data-jpa")
 
     runtimeOnly("com.mysql:mysql-connector-j")
 }

--- a/modules/jpa/build.gradle.kts
+++ b/modules/jpa/build.gradle.kts
@@ -1,9 +1,14 @@
 plugins {
     alias(libs.plugins.kotlin.jpa)
+    `java-test-fixtures`
 }
 
 dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
 
     runtimeOnly("com.mysql:mysql-connector-j")
+
+    testImplementation("org.testcontainers:mysql")
+    testFixturesImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    testFixturesImplementation("org.testcontainers:mysql")
 }

--- a/modules/jpa/src/testFixtures/kotlin/com/localtalk/config/MysqlTestContainerConfig.kt
+++ b/modules/jpa/src/testFixtures/kotlin/com/localtalk/config/MysqlTestContainerConfig.kt
@@ -1,0 +1,31 @@
+package com.localtalk.config
+
+import org.springframework.context.annotation.Configuration
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.utility.DockerImageName
+
+@Configuration
+class MysqlTestContainerConfig {
+    companion object {
+        private val mySqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.0"))
+            .apply {
+                withDatabaseName("localtalk")
+                withUsername("test")
+                withPassword("test")
+                withExposedPorts(3306)
+                withCommand(
+                    "--character-set-server=utf8mb4",
+                    "--collation-server=utf8mb4_general_ci",
+                    "--skip-character-set-client-handshake",
+                )
+                start()
+            }
+
+        init {
+            val mySqlJdbcUrl = mySqlContainer.let { "jdbc:mysql://${it.host}:${it.firstMappedPort}/${it.databaseName}" }
+            System.setProperty("datasource.hikari.master.jdbc-url", mySqlJdbcUrl)
+            System.setProperty("datasource.hikari.master.username", mySqlContainer.username)
+            System.setProperty("datasource.hikari.master.password", mySqlContainer.password)
+        }
+    }
+}

--- a/modules/jpa/src/testFixtures/kotlin/com/localtalk/utils/JpaDatabaseCleaner.kt
+++ b/modules/jpa/src/testFixtures/kotlin/com/localtalk/utils/JpaDatabaseCleaner.kt
@@ -1,0 +1,32 @@
+package com.localtalk.utils
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.Table
+import jakarta.transaction.Transactional
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.stereotype.Component
+
+@Component
+class JpaDatabaseCleaner(
+    @PersistenceContext private val entityManager: EntityManager,
+) : InitializingBean {
+    private val tableNames = mutableListOf<String>()
+
+    override fun afterPropertiesSet() {
+        entityManager.metamodel.entities.filter { entity -> entity.javaType.getAnnotation(Entity::class.java) != null }
+            .map { entity -> entity.javaType.getAnnotation(Table::class.java).name }.forEach { tableNames.add(it) }
+    }
+
+    @Transactional
+    fun truncateAllTables() {
+        entityManager.flush()
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate()
+        tableNames.forEach { table ->
+            entityManager.createNativeQuery("TRUNCATE TABLE `$table`").executeUpdate()
+        }
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate()
+    }
+
+}


### PR DESCRIPTION
## PR 설명
- [🐛 fix : JPA 모듈을 다른 라이브러리에서 쓸 수 있도록 api로 변경](https://github.com/local-talk/local-talk-BE/commit/c0ae8cc1e75351523e2226f67d2d7b5ce0d3a70a)
  - JPA 의존성을 implementation에서 api로 변경하여 다른 모듈에서 JPA 관련 어노테이션과 클래스에 직접 접근할 수 있도록 했습니다.
  - 기존에는 다른 모듈에서 @Entity, @Repository 등을 사용하려면 별도로 JPA 의존성을 추가해야 했는데, 이제는 JPA 모듈만
  의존하면 자동으로 사용할 수 있습니다.
- [✨ feat : 테스트 라이프사이클에서 동작하는 MySQL 테스트 컨테이너 추가](https://github.com/local-talk/local-talk-BE/commit/d29cab75861f99bf06c8c49976804d3a9365bd38)
  - java-test-fixtures 플러그인과 MysqlTestContainerConfig를 추가하여 MySQL 8.0 TestContainer가 자동으로 시작되고 데이터소스 설정이 주입되도록 구현했습니다.
  - @Import(MysqlTestContainerConfig::class) 어노테이션 하나만 추가하면 Docker로 MySQL
  컨테이너가 시작되고, UTF8MB4 인코딩과 함께 테스트용 데이터베이스가 자동 설정됩니다.
  - 시스템 프로퍼티로 HikariCP 설정이 주입되어 별도 설정 없이 바로 사용할 수 있습니다.
- [✨ feat : 테스트시 테이블의 데이터를 전부 초기화하는 기능 구현](https://github.com/local-talk/local-talk-BE/commit/ae2de2f9a91f092536505d33b82b9114c0cc1479)
  - JpaDatabaseCleaner를 구현하여 테스트 간 모든 테이블의 데이터를 TRUNCATE하고 FOREIGN KEY 제약조건을 안전하게 처리하는 기능을 추가했습니다.
  - EntityManager의 메타데이터를 활용해 모든 @Entity 클래스를 자동으로 찾고, 해당 테이블들을 TRUNCATE합니다.
  - FOREIGN KEY 제약조건 때문에 삭제가 실패하는 것을 방지하기 위해 작업 전후로 FOREIGN_KEY_CHECKS를 제어합니다.
-   [📝 docs : JPA 모듈 문서화](https://github.com/local-talk/local-talk-BE/commit/ecbf7cd37989959ef2ea618761377a1c53ad7c27)
  - JPA 모듈의 사용법, testFixtures 활용법, 설정 방법을 포함한 README.md를 작성하여 다른 개발자가 쉽게 활용할 수 있도록 했습니다.
 

## 작업 내용

- [x]  JPA 모듈 의존성을 api로 변경
- [x] java-test-fixtures 플러그인 추가
- [x] MySQL TestContainer 자동 설정 구현
- [x] JpaDatabaseCleaner 테이블 정리 유틸리티 구현
- [x] testFixtures 의존성 설정 및 동작 검증
- [x] JPA 모듈 README.md 문서 작성

## 참고
- [java-test-fixture 설명](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures)