### PR TITLE
✨ feat : 시큐리티 설정 추가 및 통합 테스트 템플릿 및 통합 테스트 작성

### DIFF
--- a/apps/localtalk-api/build.gradle.kts
+++ b/apps/localtalk-api/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":supports:logging"))
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
     implementation(libs.jjwt.api)
     runtimeOnly(libs.jjwt.impl)
@@ -29,4 +31,5 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 
     testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:webclient")))
 }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/SocialLoginApplicationService.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/SocialLoginApplicationService.kt
@@ -2,8 +2,8 @@ package com.localtalk.api.auth.application
 
 import com.localtalk.api.auth.application.dto.SocialLoginCommand
 import com.localtalk.api.auth.application.dto.SocialLoginInfo
-import com.localtalk.api.auth.domain.contract.ExternalTokenValidator
 import com.localtalk.api.auth.domain.AuthRole
+import com.localtalk.api.auth.domain.contract.ExternalTokenValidator
 import com.localtalk.api.auth.domain.service.SocialLoginService
 import com.localtalk.api.auth.domain.service.TokenService
 import org.springframework.stereotype.Service

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
@@ -1,0 +1,59 @@
+package com.localtalk.api.auth.config
+
+import com.localtalk.api.auth.domain.AuthRole
+import com.localtalk.api.auth.infrastructure.token.ID_CLAIM
+import com.localtalk.api.auth.infrastructure.token.JwtTokenDecoder
+import com.localtalk.api.auth.infrastructure.token.ROLE_CLAIM
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    val jwtTokenDecoder: JwtTokenDecoder,
+) {
+
+    @Bean
+    fun jwtDecoder(): JwtDecoder = JwtDecoder { token ->
+        jwtTokenDecoder.decodeToJwt(token)
+    }
+
+
+    @Bean
+    fun jwtAuthenticationConverter(): JwtAuthenticationConverter = JwtAuthenticationConverter().apply {
+        setJwtGrantedAuthoritiesConverter { jwt ->
+            val role = jwt.getClaim<String>(ROLE_CLAIM)
+            listOf(SimpleGrantedAuthority("ROLE_$role"))
+        }
+        setPrincipalClaimName(ID_CLAIM)
+    }
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .csrf { it.disable() }
+            .httpBasic { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers("/api/v1/social-logins/**").permitAll()
+                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                    .requestMatchers("/api/v1/**").hasRole(AuthRole.MEMBER.name)
+                    .anyRequest().authenticated()
+            }
+            .oauth2ResourceServer { oauth2 ->
+                oauth2.jwt { jwt ->
+                    jwt.decoder(jwtDecoder())
+                        .jwtAuthenticationConverter(jwtAuthenticationConverter())
+                }
+            }
+            .build()
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/LoginToken.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/LoginToken.kt
@@ -1,13 +1,6 @@
 package com.localtalk.api.auth.domain
 
-import com.localtalk.domain.BaseEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Table
-
-@Entity
-@Table(name = "login_token")
-class LoginToken(
-    @Column(name = "refresh_token", nullable = false)
+data class LoginToken(
+    val accessToken: String,
     val refreshToken: String,
-) : BaseEntity()
+)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/RefreshToken.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/RefreshToken.kt
@@ -1,0 +1,13 @@
+package com.localtalk.api.auth.domain
+
+import com.localtalk.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "refresh_token")
+class RefreshToken(
+    @Column(name = "token", nullable = false)
+    val token: String,
+) : BaseEntity()

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/LoginTokenRepository.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/LoginTokenRepository.kt
@@ -1,6 +1,0 @@
-package com.localtalk.api.auth.domain.contract
-
-import com.localtalk.api.auth.domain.LoginToken
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface LoginTokenRepository : JpaRepository<LoginToken, Long>

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/RefreshTokenRepository.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/RefreshTokenRepository.kt
@@ -1,0 +1,6 @@
+package com.localtalk.api.auth.domain.contract
+
+import com.localtalk.api.auth.domain.RefreshToken
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long>

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/TokenProvider.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/TokenProvider.kt
@@ -1,7 +1,5 @@
 package com.localtalk.api.auth.domain.contract
 
-import com.localtalk.api.auth.domain.AuthRole
-
 interface TokenProvider {
-    fun generateToken(userId: Long, authRole: AuthRole): Pair<String, String>
+    fun generateToken(id: Long, role: String): Pair<String, String>
 }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/service/TokenService.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/service/TokenService.kt
@@ -2,20 +2,22 @@ package com.localtalk.api.auth.domain.service
 
 import com.localtalk.api.auth.domain.AuthRole
 import com.localtalk.api.auth.domain.LoginToken
-import com.localtalk.api.auth.domain.contract.LoginTokenRepository
+import com.localtalk.api.auth.domain.RefreshToken
+import com.localtalk.api.auth.domain.contract.RefreshTokenRepository
 import com.localtalk.api.auth.domain.contract.TokenProvider
 import org.springframework.stereotype.Service
 
 @Service
 class TokenService(
     val tokenProvider: TokenProvider,
-    val loginTokenRepository: LoginTokenRepository,
+    val refreshTokenRepository: RefreshTokenRepository,
 ) {
 
     fun generateToken(id: Long, authRole: AuthRole): LoginToken {
-        val (accessToken, refreshToken) = tokenProvider.generateToken(id, authRole)
-        val loginToken = LoginToken(accessToken, refreshToken)
-        return loginTokenRepository.save(loginToken)
+        return tokenProvider.generateToken(id, authRole.name)
+            .also { (_, refreshToken) -> refreshTokenRepository.save(RefreshToken(refreshToken)) }
+            .let { (accessToken, refreshToken) -> LoginToken(accessToken, refreshToken) }
     }
 
 }
+

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/dto/SocialLoginRequest.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/dto/SocialLoginRequest.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "소셜 로그인 요청")
 data class SocialLoginRequest(
-    @Schema(description = "소셜 로그인 액세스 토큰", example = "kakao_access_token_example", required = true)
+    @field:Schema(description = "소셜 로그인 액세스 토큰", example = "kakao_access_token_example", required = true)
     val accessToken: String?,
 ) {
     init {

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/client/KakaoApiClient.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/client/KakaoApiClient.kt
@@ -2,6 +2,7 @@ package com.localtalk.api.auth.infrastructure.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -10,17 +11,20 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 class KakaoApiClient(
     val webClient: WebClient,
     val objectMapper: ObjectMapper,
+    @param:Value("\${kakao.api.base-url}") val baseUrl: String,
 ) {
 
     companion object {
-        private const val KAKAO_TOKEN_INFO_URL = "https://kapi.kakao.com/v1/user/access_token_info"
+        private const val TOKEN_INFO_PATH = "/v1/user/access_token_info"
     }
 
     suspend fun validateToken(accessToken: String): KakaoAccessTokenQueryResponse {
+        val requestUrl = "$baseUrl$TOKEN_INFO_PATH"
+
         return try {
             webClient
                 .get()
-                .uri(KAKAO_TOKEN_INFO_URL)
+                .uri(requestUrl)
                 .header("Authorization", "Bearer $accessToken")
                 .retrieve()
                 .bodyToMono(KakaoAccessTokenQueryResponse::class.java)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenDecoder.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenDecoder.kt
@@ -1,0 +1,37 @@
+package com.localtalk.api.auth.infrastructure.token
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+
+private const val JWT_TYPE = "JWT"
+private const val HEADER_TYPE = "typ"
+private const val HEADER_ALGORITHM = "alg"
+
+@Component
+@EnableConfigurationProperties(JwtProperties::class)
+class JwtTokenDecoder(
+    jwtProperties: JwtProperties,
+) {
+    val tokenHandler = JwtTokenHandler(jwtProperties.secret)
+
+    fun decodeToJwt(token: String): Jwt {
+        val claims = tokenHandler.parseToken(token)
+        return Jwt.withTokenValue(token)
+            .header(HEADER_TYPE, JWT_TYPE)
+            .header(HEADER_ALGORITHM, Jwts.SIG.HS256.id)
+            .claims { claimsMap ->
+                claims.forEach { (key, value) ->
+                    claimsMap[key] = when (key) {
+                        Claims.ISSUED_AT, Claims.EXPIRATION -> Instant.ofEpochSecond((value as Number).toLong())
+                        else -> value
+                    }
+                }
+            }
+            .build()
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenHandler.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenHandler.kt
@@ -1,5 +1,6 @@
 package com.localtalk.api.auth.infrastructure.token
 
+import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import java.nio.charset.StandardCharsets
@@ -7,22 +8,31 @@ import java.time.Instant
 import java.util.Date
 import javax.crypto.SecretKey
 
-class JwtTokenGenerator(
+const val ID_CLAIM = "id"
+const val ROLE_CLAIM = "role"
+
+class JwtTokenHandler(
     secretKey: String,
 ) {
 
     val key: SecretKey = Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
 
     fun createToken(
-        userId: Long,
+        id: Long,
         role: String,
         issuedAt: Instant,
         expiresAt: Instant,
     ): String = Jwts.builder()
-        .claim("userId", userId)
-        .claim("role", role)
+        .claim(ID_CLAIM, id)
+        .claim(ROLE_CLAIM, role)
         .issuedAt(Date.from(issuedAt))
         .expiration(Date.from(expiresAt))
         .signWith(key)
         .compact()
+
+    fun parseToken(token: String): Claims = Jwts.parser()
+        .verifyWith(key)
+        .build()
+        .parseSignedClaims(token)
+        .payload
 }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenProvider.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenProvider.kt
@@ -1,6 +1,5 @@
 package com.localtalk.api.auth.infrastructure.token
 
-import com.localtalk.api.auth.domain.AuthRole
 import com.localtalk.api.auth.domain.contract.TokenProvider
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
@@ -14,21 +13,21 @@ class JwtTokenProvider(
     val clock: Clock = Clock.systemDefaultZone(),
 ) : TokenProvider {
 
-    val tokenGenerator = JwtTokenGenerator(jwtProperties.secret)
+    val tokenHandler = JwtTokenHandler(jwtProperties.secret)
 
-    override fun generateToken(userId: Long, authRole: AuthRole): Pair<String, String> {
+    override fun generateToken(id: Long, role: String): Pair<String, String> {
         val now = clock.instant()
 
-        val accessToken = tokenGenerator.createToken(
-            userId = userId,
-            role = authRole.name,
+        val accessToken = tokenHandler.createToken(
+            id = id,
+            role = role,
             issuedAt = now,
             expiresAt = now.plus(jwtProperties.accessTokenExpiry, ChronoUnit.SECONDS)
         )
 
-        val refreshToken = tokenGenerator.createToken(
-            userId = userId,
-            role = authRole.name,
+        val refreshToken = tokenHandler.createToken(
+            id = id,
+            role = role,
             issuedAt = now,
             expiresAt = now.plus(jwtProperties.refreshTokenExpiry, ChronoUnit.SECONDS)
         )

--- a/apps/localtalk-api/src/main/resources/application.yml
+++ b/apps/localtalk-api/src/main/resources/application.yml
@@ -36,7 +36,7 @@ kakao:
 spring:
   config:
     activate:
-      on-profile: local, test
+      on-profile: local
 
 ---
 spring:

--- a/apps/localtalk-api/src/main/resources/application.yml
+++ b/apps/localtalk-api/src/main/resources/application.yml
@@ -28,6 +28,10 @@ jwt:
   access-token-expiry: 3600
   refresh-token-expiry: 2592000
 
+kakao:
+  api:
+    base-url: https://kapi.kakao.com
+
 ---
 spring:
   config:

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/application/SocialLoginApplicationServiceTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/application/SocialLoginApplicationServiceTest.kt
@@ -1,8 +1,11 @@
 package com.localtalk.api.auth.application
 
 import com.localtalk.api.auth.application.dto.SocialLoginCommand
+import com.localtalk.api.auth.domain.AuthRole
+import com.localtalk.api.auth.domain.LoginToken
+import com.localtalk.api.auth.domain.SocialLogin
 import com.localtalk.api.auth.domain.SocialLoginIdentifier
-import com.localtalk.api.auth.domain.*
+import com.localtalk.api.auth.domain.SocialLoginProvider
 import com.localtalk.api.auth.domain.contract.ExternalTokenValidator
 import com.localtalk.api.auth.domain.service.SocialLoginService
 import com.localtalk.api.auth.domain.service.TokenService

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/SocialLoginControllerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/SocialLoginControllerTest.kt
@@ -1,0 +1,107 @@
+package com.localtalk.api.auth.entrypoint
+
+import com.localtalk.api.config.KakaoApiMockServer
+import com.localtalk.api.support.IntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+
+class SocialLoginControllerTest : IntegrationTest() {
+
+    @Test
+    fun `카카오 소셜 로그인 성공 시 토큰을 반환한다`() {
+        val validAccessToken = "valid_kakao_access_token"
+
+        KakaoApiMockServer.enqueueSuccessResponse(id = 123456789L, expiresIn = 3600, appId = 12345)
+
+        val response = webTestClient
+            .post()
+            .uri("/api/v1/social-logins/kakao")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"access_token":"$validAccessToken"}""")
+            .exchange()
+
+        response
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.code").isEqualTo(HttpStatus.OK.value())
+            .jsonPath("$.message").isEqualTo("소셜 로그인이 성공했습니다")
+            .jsonPath("$.data.access_token").isNotEmpty
+            .jsonPath("$.data.refresh_token").isNotEmpty
+            .jsonPath("$.data.is_signed_user").isEqualTo(false)
+    }
+
+    @Test
+    fun `잘못된 카카오 액세스 토큰으로 요청 시 400 에러를 반환한다`() {
+        val invalidAccessToken = "invalid_kakao_access_token"
+
+        KakaoApiMockServer.enqueueErrorResponse(code = -401, message = "Invalid token")
+
+        val response = webTestClient
+            .post()
+            .uri("/api/v1/social-logins/kakao")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"access_token":"$invalidAccessToken"}""")
+            .exchange()
+
+        response
+            .expectStatus().isBadRequest
+            .expectBody()
+            .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+            .jsonPath("$.message").isEqualTo("카카오 API 오류 - Invalid token (코드: -401)")
+    }
+
+    @Test
+    fun `지원하지 않는 소셜 로그인 프로바이더로 요청 시 400 에러를 반환한다`() {
+        val accessToken = "some_token"
+        val provider = "invalid_provider"
+
+        val response = webTestClient
+            .post()
+            .uri("/api/v1/social-logins/{provider}", provider)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"access_token":"$accessToken"}""")
+            .exchange()
+
+        response
+            .expectStatus().isBadRequest
+            .expectBody()
+            .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+            .jsonPath("$.message").isEqualTo("지원하지 않는 소셜 로그인 프로바이더입니다: $provider")
+    }
+
+    @Test
+    fun `액세스 토큰이 null인 경우 400 에러를 반환한다`() {
+        val requestBody = """{"access_token": null}"""
+
+        val response = webTestClient
+            .post()
+            .uri("/api/v1/social-logins/kakao")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(requestBody)
+            .exchange()
+
+        response
+            .expectStatus().isBadRequest
+            .expectBody()
+            .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+            .jsonPath("$.message").isEqualTo("액세스 토큰을 입력해주세요.")
+    }
+
+    @Test
+    fun `액세스 토큰이 빈 문자열인 경우 400 에러를 반환한다`() {
+        val response = webTestClient
+            .post()
+            .uri("/api/v1/social-logins/kakao")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"access_token":""}""")
+            .exchange()
+
+        response
+            .expectStatus().isBadRequest
+            .expectBody()
+            .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+            .jsonPath("$.message").isEqualTo("액세스 토큰은 빈 값일 수 없습니다.")
+    }
+
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/infrastructure/JwtTokenHandlerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/infrastructure/JwtTokenHandlerTest.kt
@@ -1,16 +1,16 @@
 package com.localtalk.api.auth.infrastructure
 
-import com.localtalk.api.auth.infrastructure.token.JwtTokenGenerator
+import com.localtalk.api.auth.infrastructure.token.JwtTokenHandler
 import com.localtalk.api.utils.JwtTestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
-class JwtTokenGeneratorTest {
+class JwtTokenHandlerTest {
 
     val secretKey = "test-secret-key-for-jwt-token-generation-must-be-long-enough-for-hmac-sha256"
-    val jwtTokenGenerator = JwtTokenGenerator(secretKey)
+    val jwtTokenHandler = JwtTokenHandler(secretKey)
 
     @Nested
     inner class `JWT 토큰을 생성할 때` {
@@ -22,7 +22,7 @@ class JwtTokenGeneratorTest {
             val issuedAt = Instant.now()
             val expiresAt = issuedAt.plusSeconds(3600)
 
-            val token = jwtTokenGenerator.createToken(userId, role, issuedAt, expiresAt)
+            val token = jwtTokenHandler.createToken(userId, role, issuedAt, expiresAt)
 
             assertThat(JwtTestUtils.isValidJwtFormat(token)).isTrue()
         }

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenDecoderTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenDecoderTest.kt
@@ -1,0 +1,104 @@
+package com.localtalk.api.auth.infrastructure.token
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.Date
+import javax.crypto.SecretKey
+
+class JwtTokenDecoderTest {
+
+    val jwtProperties = JwtProperties(
+        secret = SECRET_KEY,
+        accessTokenExpiry = 3600,
+        refreshTokenExpiry = 86400,
+    )
+    val jwtTokenDecoder = JwtTokenDecoder(jwtProperties)
+    val key: SecretKey = Keys.hmacShaKeyFor(SECRET_KEY.toByteArray(StandardCharsets.UTF_8))
+
+    @Nested
+    inner class `JWT 토큰을 디코딩할 때` {
+
+        @Test
+        fun `날짜 클레임이 포함된 토큰을 올바르게 디코딩한다`() {
+            val issuedAt = Instant.ofEpochSecond(Instant.now().epochSecond)
+            val expiresAt = issuedAt.plusSeconds(3600)
+
+            val token = Jwts.builder()
+                .claim(ID_CLAIM, 123L)
+                .claim(ROLE_CLAIM, "MEMBER")
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiresAt))
+                .signWith(key)
+                .compact()
+
+            val result = jwtTokenDecoder.decodeToJwt(token)
+
+            assertThat(result.tokenValue).isEqualTo(token)
+            assertThat(result.getClaim<Long>(ID_CLAIM)).isEqualTo(123L)
+            assertThat(result.getClaim<String>(ROLE_CLAIM)).isEqualTo("MEMBER")
+            assertThat(result.issuedAt).isEqualTo(issuedAt)
+            assertThat(result.expiresAt).isEqualTo(expiresAt)
+        }
+
+        @Test
+        fun `일반 클레임만 있는 토큰을 올바르게 디코딩한다`() {
+            val token = Jwts.builder()
+                .claim(ID_CLAIM, 456L)
+                .claim(ROLE_CLAIM, "TEMPORARY")
+                .claim("customClaim", "customValue")
+                .signWith(key)
+                .compact()
+
+            val result = jwtTokenDecoder.decodeToJwt(token)
+
+            assertThat(result.tokenValue).isEqualTo(token)
+            assertThat(result.getClaim<Long>(ID_CLAIM)).isEqualTo(456L)
+            assertThat(result.getClaim<String>(ROLE_CLAIM)).isEqualTo("TEMPORARY")
+            assertThat(result.getClaim<String>("customClaim")).isEqualTo("customValue")
+        }
+
+        @Test
+        fun `헤더 정보가 올바르게 설정된다`() {
+            val token = Jwts.builder()
+                .claim(ID_CLAIM, 123L)
+                .signWith(key)
+                .compact()
+
+            val result = jwtTokenDecoder.decodeToJwt(token)
+
+            assertThat(result.headers).containsEntry("typ", "JWT")
+            assertThat(result.headers).containsEntry("alg", "HS256")
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", "invalid.jwt.token"])
+        fun `잘못된 형식의 토큰이면 예외를 발생시킨다`(invalidToken: String) {
+            assertThatThrownBy { jwtTokenDecoder.decodeToJwt(invalidToken) }
+                .isInstanceOf(Exception::class.java)
+        }
+
+        @Test
+        fun `다른 키로 서명된 토큰이면 예외를 발생시킨다`() {
+            val wrongKey = Keys.hmacShaKeyFor("wrong-secret-key-different-from-original-key-for-testing".toByteArray(StandardCharsets.UTF_8))
+            val token = Jwts.builder()
+                .claim(ID_CLAIM, 123L)
+                .signWith(wrongKey)
+                .compact()
+
+            assertThatThrownBy { jwtTokenDecoder.decodeToJwt(token) }
+                .isInstanceOf(Exception::class.java)
+        }
+    }
+
+    companion object {
+        const val SECRET_KEY = "test-secret-key-for-jwt-token-generation-must-be-long-enough-for-hmac-sha256"
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/common/exception/GlobalExceptionHandlerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/common/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,184 @@
+package com.localtalk.api.common.exception
+
+import com.localtalk.api.support.IntegrationTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/test-rest-api-exceptions")
+class RestApiTestController {
+
+    @GetMapping("/get-only")
+    fun getOnlyEndpoint(): String = "GET only"
+
+    @PostMapping("/post-only", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun postOnlyEndpoint(@RequestBody request: TestRequest): String = "POST only"
+}
+
+@RestController
+@RequestMapping("/test-json-exceptions")
+class JsonTestController {
+
+    @PostMapping("/validation-error")
+    fun validationErrorEndpoint(@RequestBody request: TestRequest): String = "success"
+}
+
+@RestController
+@RequestMapping("/test-argument-exceptions")
+class ArgumentTestController {
+
+    @GetMapping("/illegal-argument")
+    fun throwIllegalArgumentException(): String {
+        throw IllegalArgumentException("테스트용 IllegalArgumentException")
+    }
+}
+
+@RestController
+@RequestMapping("/test-generic-exceptions")
+class GenericTestController {
+
+    @GetMapping("/runtime-exception")
+    fun throwRuntimeException(): String {
+        throw RuntimeException("테스트용 RuntimeException")
+    }
+}
+
+data class TestRequest(
+    val validField: String?,
+) {
+    init {
+        require(!validField.isNullOrBlank()) { "validField는 필수이며 빈 값일 수 없습니다" }
+    }
+}
+
+@DisplayName("GlobalExceptionHandler 테스트")
+class GlobalExceptionHandlerTest : IntegrationTest() {
+
+    @Nested
+    @DisplayName("REST API 예외 처리")
+    inner class RestApiExceptionHandling {
+
+        @Test
+        fun `지원하지 않는 HTTP 메서드 요청시 400 상태코드를 반환한다`() {
+            webTestClient.post()
+                .uri("/test-rest-api-exceptions/get-only")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+                .jsonPath("$.message").isNotEmpty
+                .jsonPath("$.data").isEmpty
+        }
+
+        @Test
+        fun `잘못된 Content-Type으로 요청시 400 상태코드를 반환한다`() {
+            webTestClient.post()
+                .uri("/test-rest-api-exceptions/post-only")
+                .contentType(MediaType.TEXT_PLAIN)
+                .bodyValue("plain text")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+                .jsonPath("$.message").isNotEmpty
+                .jsonPath("$.data").isEmpty
+        }
+    }
+
+    @Nested
+    @DisplayName("HttpMessageNotReadableException 처리")
+    inner class HttpMessageNotReadableExceptionHandling {
+
+        @Test
+        fun `잘못된 JSON 형식 요청시 400 상태코드와 형식 오류 메시지를 반환한다`() {
+            webTestClient.post()
+                .uri("/test-json-exceptions/validation-error")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("{invalid json}")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+                .jsonPath("$.message").isEqualTo("잘못된 요청 형식입니다.")
+                .jsonPath("$.data").isEmpty
+        }
+
+        @Test
+        fun `JSON 파싱 중 IllegalArgumentException 발생시 해당 예외 메시지를 반환한다`() {
+            webTestClient.post()
+                .uri("/test-json-exceptions/validation-error")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"validField": ""}""")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+                .jsonPath("$.message").isEqualTo("validField는 필수이며 빈 값일 수 없습니다")
+                .jsonPath("$.data").isEmpty
+        }
+
+        @Test
+        fun `JSON 파싱 중 IllegalArgumentException 발생시 null인 경우 기본 메시지를 반환한다`() {
+            webTestClient.post()
+                .uri("/test-json-exceptions/validation-error")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"validField": null}""")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+                .jsonPath("$.message").isEqualTo("validField는 필수이며 빈 값일 수 없습니다")
+                .jsonPath("$.data").isEmpty
+        }
+    }
+
+    @Nested
+    @DisplayName("IllegalArgumentException 처리")
+    inner class IllegalArgumentExceptionHandling {
+
+        @Test
+        fun `직접 던진 IllegalArgumentException 발생시 400 상태코드와 예외 메시지를 반환한다`() {
+            webTestClient.get()
+                .uri("/test-argument-exceptions/illegal-argument")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.BAD_REQUEST.value())
+                .jsonPath("$.message").isEqualTo("테스트용 IllegalArgumentException")
+                .jsonPath("$.data").isEmpty
+        }
+    }
+
+    @Nested
+    @DisplayName("일반 예외 처리")
+    inner class GenericExceptionHandling {
+
+        @Test
+        fun `Exception 발생시 500 상태코드와 서버 오류 메시지를 반환한다`() {
+            webTestClient.get()
+                .uri("/test-generic-exceptions/runtime-exception")
+                .exchange()
+                .expectStatus().is5xxServerError
+                .expectBody()
+                .jsonPath("$.code").isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .jsonPath("$.message").isEqualTo("서버 내부 오류가 발생했습니다.")
+                .jsonPath("$.data").isEmpty
+        }
+
+        @Test
+        fun `존재하지 않는 엔드포인트 요청시 404 상태코드를 반환한다`() {
+            webTestClient.get()
+                .uri("/non-existent-endpoint")
+                .exchange()
+                .expectStatus().isNotFound
+        }
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/config/KakaoApiMockServer.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/config/KakaoApiMockServer.kt
@@ -1,0 +1,51 @@
+package com.localtalk.api.config
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.springframework.boot.test.context.TestConfiguration
+
+@TestConfiguration
+class KakaoApiMockServer {
+
+    companion object {
+        private val mockWebServer: MockWebServer = MockWebServer().apply { start() }
+
+        init {
+            System.setProperty("kakao.api.base-url", mockWebServer.url("/").toString())
+        }
+
+        fun enqueueSuccessResponse(id: Long, expiresIn: Int = 3600, appId: Int = 12345) {
+            val responseBody = """
+                {
+                    "id": $id,
+                    "expires_in": $expiresIn,
+                    "app_id": $appId
+                }
+            """.trimIndent()
+
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(responseBody),
+            )
+            println("MockWebServer: Enqueued success response for id=$id, port=${mockWebServer.port}")
+        }
+
+        fun enqueueErrorResponse(code: Int, message: String) {
+            val responseBody = """
+                {
+                    "msg": "$message",
+                    "code": $code
+                }
+            """.trimIndent()
+
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(401)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody(responseBody),
+            )
+        }
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/IntegrationTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/IntegrationTest.kt
@@ -1,0 +1,29 @@
+package com.localtalk.api.support
+
+import com.localtalk.api.config.KakaoApiMockServer
+import com.localtalk.config.MysqlTestContainerConfig
+import com.localtalk.utils.JpaDatabaseCleaner
+import com.localtalk.webclient.config.WebTestClientConfig
+import org.junit.jupiter.api.AfterEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(MysqlTestContainerConfig::class, KakaoApiMockServer::class, WebTestClientConfig::class)
+@ActiveProfiles("test")
+abstract class IntegrationTest {
+
+    @Autowired
+    protected lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    protected lateinit var databaseCleaner: JpaDatabaseCleaner
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleaner.truncateAllTables()
+    }
+}

--- a/apps/localtalk-api/src/test/resources/application.yml
+++ b/apps/localtalk-api/src/test/resources/application.yml
@@ -1,0 +1,30 @@
+spring:
+  profiles:
+    active: test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+jwt:
+  secret: testSecretKeyForIntegrationTestOnlyNotForProduction123456789
+  access-token-expiry: 3600
+  refresh-token-expiry: 2592000
+
+client:
+  webclient:
+    connect-timeout: 5s
+    response-timeout: 5s
+    read-timeout: 5s
+    write-timeout: 5s
+    max-in-memory-size: 1048576 # 1MB
+    max-connections: 100
+    pending-acquire-timeout: 10s
+
+
+kakao:
+  api:
+    base-url: http://localhost:${kakao.api.mock.port:0}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ springdoc-openapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-u
 
 spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-test = { module = "org.springframework:spring-test" }
 reactor-test = { module = "io.projectreactor:reactor-test" }
 
 [plugins]

--- a/modules/webclient/build.gradle.kts
+++ b/modules/webclient/build.gradle.kts
@@ -1,7 +1,14 @@
+plugins {
+    `java-test-fixtures`
+}
+
 dependencies {
     api(libs.spring.boot.starter.webflux)
     api(libs.spring.boot.configuration.processor)
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(libs.reactor.test)
+
+    testFixturesImplementation(libs.spring.boot.starter.test)
+    testFixturesImplementation(libs.spring.test)
 }

--- a/modules/webclient/src/testFixtures/kotlin/com/localtalk/webclient/config/WebTestClientConfig.kt
+++ b/modules/webclient/src/testFixtures/kotlin/com/localtalk/webclient/config/WebTestClientConfig.kt
@@ -1,0 +1,15 @@
+package com.localtalk.webclient.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient
+import org.springframework.web.context.WebApplicationContext
+
+@Configuration
+class WebTestClientConfig {
+
+    @Bean
+    fun webTestClient(context: WebApplicationContext): WebTestClient =
+        MockMvcWebTestClient.bindToApplicationContext(context).build()
+}


### PR DESCRIPTION
## PR 설명
- [🐛 fix : 로그인 토큰 형식을 유지하고 RTR 처리를 위한 별도의 refreshToken 저장소를 사용하도록 변경](https://github.com/local-talk/local-talk-BE/commit/bc6d4a0133776a6581dc08cbafda47e5264ee4a1)
  - 기존에 LoginToken에서 AccessToken 정보를 제거하면서 컴파일 에러가 발생하고 있었습니다. LoginToken을 별도의 데이터 클래스로 만들어 관리하고, RefreshToken이라는 엔티티를 만들어 DB에 저장하도록 변경했습니다. 
- [✅ test : 통합 테스트 템플릿 작성 및 테스트 추가](https://github.com/local-talk/local-talk-BE/commit/06f0a0782ad2601a0ffeffd75bae427575ae6f6c)
  - IntegrationTest라는 템플릿 클래스를 상속받아 통합 테스트를 작성할 수 있도록 했습니다. 통합 테스트는 해당 클래스를 상속해서 테스트를 작성하시면 됩니다. 이로인해 스프링 컨텍스트가 재활용되기 때문에 테스트 속도 향상의 이점을 챙길 수 있도록 했습니다.
  -  WebTestClient를 이용하여 테스트를 진행할 수 있도록 했습니다.
  - Kakao API 서버는 현재 애플리케이션과 다른 외부의 제어할 수 없는 요소이기 때문에 MockServer로 대체하는 방식으로 진행했습니다. 이로인해 외부 요소(카카오 API 장애, 요청량 초과 등)에 자유롭게 테스트를 실행할 수 있습니다.
- [✨ feat : 시큐리티 설정 추가](https://github.com/local-talk/local-talk-BE/commit/76f5fed258555accc0aff91a7292353354a14d3d)
  - Spring Security OAuth2 Resource Server를 사용하여 JWT 인증 인가 시스템을 만들었습니다.
  - JWT 파싱을 위해 JWTDecoder를 만들어  토큰을 검증할 수 있도록 처리했습니다.

## 작업 내용

- [x] LoginToken 컴파일 에러 해결
- [x] 통합 테스트 템플릿 작성
- [x] 카카오 API Mocking 서버 구현
- [x]  WebTestClient를 사용하여 실제와 유사한 통합 테스트 환경 구축
- [x] 시큐리티를 통해 인증 / 인가 처리 진행 