### PR TITLE
:recycle: refactor : soft delete, hard delete를 선택해서 쓸 수 있도록 BaseEntity 분리

### DIFF
--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/RefreshToken.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/RefreshToken.kt
@@ -1,6 +1,6 @@
 package com.localtalk.api.auth.domain
 
-import com.localtalk.domain.BaseEntity
+import com.localtalk.domain.HardDeleteBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
@@ -8,6 +8,6 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "refresh_token")
 class RefreshToken(
-    @Column(name = "token", nullable = false)
+    @Column(name = "token", nullable = false, unique = true)
     val token: String,
-) : BaseEntity()
+) : HardDeleteBaseEntity()

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/SocialLogin.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/SocialLogin.kt
@@ -1,6 +1,6 @@
 package com.localtalk.api.auth.domain
 
-import com.localtalk.domain.BaseEntity
+import com.localtalk.domain.SoftDeleteBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -23,6 +23,6 @@ class SocialLogin(
     @Column(name = "member_id")
     @Comment("연결된 회원 ID")
     var memberId: Long? = null,
-) : BaseEntity() {
+) : SoftDeleteBaseEntity() {
     fun isSignedUser(): Boolean = memberId != null
 }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/member/domain/Member.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/member/domain/Member.kt
@@ -1,6 +1,6 @@
 package com.localtalk.api.member.domain
 
-import com.localtalk.domain.BaseEntity
+import com.localtalk.domain.SoftDeleteBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
@@ -12,4 +12,4 @@ class Member(
     @Column(name = "nickname", nullable = false)
     @Comment("닉네임")
     val nickname: Nickname,
-) : BaseEntity()
+) : SoftDeleteBaseEntity()

--- a/modules/jpa/src/main/kotlin/com/localtalk/domain/BaseEntity.kt
+++ b/modules/jpa/src/main/kotlin/com/localtalk/domain/BaseEntity.kt
@@ -1,5 +1,6 @@
 package com.localtalk.domain
 
+import com.localtalk.internal.InternalBaseEntityApi
 import jakarta.persistence.Column
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -9,6 +10,7 @@ import jakarta.persistence.PrePersist
 import jakarta.persistence.PreUpdate
 import java.time.ZonedDateTime
 
+@InternalBaseEntityApi
 @MappedSuperclass
 abstract class BaseEntity {
     @Id
@@ -21,10 +23,6 @@ abstract class BaseEntity {
 
     @Column(name = "updated_at", nullable = false)
     lateinit var updatedAt: ZonedDateTime
-        protected set
-
-    @Column(name = "deleted_at")
-    var deletedAt: ZonedDateTime? = null
         protected set
 
     open fun validate() = Unit
@@ -42,13 +40,5 @@ abstract class BaseEntity {
     private fun preUpdate() {
         validate()
         updatedAt = ZonedDateTime.now()
-    }
-
-    fun delete() {
-        deletedAt = deletedAt ?: ZonedDateTime.now()
-    }
-
-    fun restore() {
-        deletedAt = null
     }
 }

--- a/modules/jpa/src/main/kotlin/com/localtalk/domain/HardDeleteBaseEntity.kt
+++ b/modules/jpa/src/main/kotlin/com/localtalk/domain/HardDeleteBaseEntity.kt
@@ -1,0 +1,8 @@
+package com.localtalk.domain
+
+import com.localtalk.internal.InternalBaseEntityApi
+import jakarta.persistence.MappedSuperclass
+
+@OptIn(InternalBaseEntityApi::class)
+@MappedSuperclass
+abstract class HardDeleteBaseEntity : BaseEntity()

--- a/modules/jpa/src/main/kotlin/com/localtalk/domain/SoftDeleteBaseEntity.kt
+++ b/modules/jpa/src/main/kotlin/com/localtalk/domain/SoftDeleteBaseEntity.kt
@@ -1,0 +1,22 @@
+package com.localtalk.domain
+
+import com.localtalk.internal.InternalBaseEntityApi
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+import java.time.ZonedDateTime
+
+@OptIn(InternalBaseEntityApi::class)
+@MappedSuperclass
+abstract class SoftDeleteBaseEntity : BaseEntity() {
+    @Column(name = "deleted_at")
+    var deletedAt: ZonedDateTime? = null
+        protected set
+
+    fun delete() {
+        deletedAt = deletedAt ?: ZonedDateTime.now()
+    }
+
+    fun restore() {
+        deletedAt = null
+    }
+}

--- a/modules/jpa/src/main/kotlin/com/localtalk/internal/InternalBaseEntityApi.kt
+++ b/modules/jpa/src/main/kotlin/com/localtalk/internal/InternalBaseEntityApi.kt
@@ -1,0 +1,7 @@
+package com.localtalk.internal
+
+@RequiresOptIn(
+    message = "BaseEntity 대신 SoftDeleteBaseEntity 또는 HardDeleteBaseEntity를 사용하세요.",
+    level = RequiresOptIn.Level.ERROR,
+)
+annotation class InternalBaseEntityApi


### PR DESCRIPTION
## PR 설명

베이스 엔티티 구조를 개선하여 엔티티별 삭제 정책을 명확히 하고, 실수로 잘못된 베이스 엔티티를 사용하는 것을 방지하기 위한 PR입니다.

### 문제점

- 기존 BaseEntity는 무조건 소프트 딜리트만 지원
- 토큰 등 완전 삭제가 필요한 엔티티에는 부적절

### 해결방안
- soft delete와 hard delete를 지원하는 각각의 baseEntity를 만들도록 변경

### Commit 내용
 - [♻️ refactor : soft delete, hard delete를 선택해서 쓸 수 있도록 BaseEntity 분리](https://github.com/local-talk/local-talk-BE/commit/119e5d90d0938ff572c2f3f5f4b1c5ea35793855)
   -  SoftDeleteBaseEntity와 HardDeleteBaseEntity로 분리하여 용도별 선택 가능
   - @RequiresOptIn 메커니즘으로 BaseEntity 직접 사용 방지
   - 모듈 내부의 규칙을 정의하는 클래스(OptIn 관련 등) internal 패키지에 위치하도록 구조 변경


## 작업 내용

- [x] Soft Delete와 Hard Delete 구조 분리
- [x] OptIn을 통해 사용가능한 클래스 제한
- [x] 현재 구현에 맞게 README.md 문서 수정 

## 리뷰 포인트

<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    리뷰 받고 싶은 코드가 있다면 해당 코드에 대해 코멘트를 달아주시면 좋습니다. 
-->

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->