### PR TITLE
✨ feat : 리프레시 토큰 갱신(RTR) 기능 구현

### DIFF
--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/TokenApplicationService.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/TokenApplicationService.kt
@@ -1,0 +1,20 @@
+package com.localtalk.api.auth.application
+
+import com.localtalk.api.auth.application.dto.RefreshTokenCommand
+import com.localtalk.api.auth.application.dto.TokenRefreshInfo
+import com.localtalk.api.auth.domain.service.TokenService
+import org.springframework.stereotype.Service
+
+@Service
+class TokenApplicationService(
+    val tokenService: TokenService,
+) {
+    fun rotateRefreshToken(command: RefreshTokenCommand): TokenRefreshInfo {
+        val loginToken = tokenService.rotateRefreshToken(command.refreshToken)
+
+        return TokenRefreshInfo(
+            accessToken = loginToken.accessToken,
+            refreshToken = loginToken.refreshToken,
+        )
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/dto/RefreshTokenCommand.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/dto/RefreshTokenCommand.kt
@@ -1,0 +1,9 @@
+package com.localtalk.api.auth.application.dto
+
+data class RefreshTokenCommand(
+    val refreshToken: String,
+) {
+    init {
+        require(refreshToken.isNotBlank()) { "유효한 리프레시 토큰을 입력해주세요" }
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/dto/TokenRefreshInfo.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/application/dto/TokenRefreshInfo.kt
@@ -1,0 +1,6 @@
+package com.localtalk.api.auth.application.dto
+
+data class TokenRefreshInfo(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
@@ -31,6 +31,7 @@ class SecurityConfig(
                 auth
                     .requestMatchers("/api/v1/social-logins/**").permitAll()
                     .requestMatchers("/api/v1/districts/**").permitAll()
+                    .requestMatchers("/api/v1/auth/refresh").permitAll()
                     .requestMatchers("/api/v1/members/nickname/validate").authenticated()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/api/v1/**").hasRole(AuthRole.MEMBER.name)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
@@ -1,17 +1,13 @@
 package com.localtalk.api.auth.config
 
 import com.localtalk.api.auth.domain.AuthRole
-import com.localtalk.api.auth.infrastructure.token.ID_CLAIM
 import com.localtalk.api.auth.infrastructure.token.JwtTokenDecoder
-import com.localtalk.api.auth.infrastructure.token.ROLE_CLAIM
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.jwt.JwtDecoder
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.web.SecurityFilterChain
 
 @Configuration
@@ -23,16 +19,6 @@ class SecurityConfig(
     @Bean
     fun jwtDecoder(): JwtDecoder = JwtDecoder { token ->
         jwtTokenDecoder.decodeToJwt(token)
-    }
-
-
-    @Bean
-    fun jwtAuthenticationConverter(): JwtAuthenticationConverter = JwtAuthenticationConverter().apply {
-        setJwtGrantedAuthoritiesConverter { jwt ->
-            val role = jwt.getClaim<String>(ROLE_CLAIM)
-            listOf(SimpleGrantedAuthority("ROLE_$role"))
-        }
-        setPrincipalClaimName(ID_CLAIM)
     }
 
     @Bean
@@ -53,7 +39,6 @@ class SecurityConfig(
             .oauth2ResourceServer { oauth2 ->
                 oauth2.jwt { jwt ->
                     jwt.decoder(jwtDecoder())
-                        .jwtAuthenticationConverter(jwtAuthenticationConverter())
                 }
             }
             .build()

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/AuthMember.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/AuthMember.kt
@@ -1,0 +1,6 @@
+package com.localtalk.api.auth.domain
+
+class AuthMember(
+    val id: Long,
+    val role: AuthRole,
+)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/RefreshToken.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/RefreshToken.kt
@@ -9,5 +9,9 @@ import jakarta.persistence.Table
 @Table(name = "refresh_token")
 class RefreshToken(
     @Column(name = "token", nullable = false, unique = true)
-    val token: String,
-) : HardDeleteBaseEntity()
+    var token: String,
+) : HardDeleteBaseEntity() {
+    fun update(token: String) {
+        this.token = token
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/RefreshTokenRepository.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/RefreshTokenRepository.kt
@@ -3,4 +3,6 @@ package com.localtalk.api.auth.domain.contract
 import com.localtalk.api.auth.domain.RefreshToken
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RefreshTokenRepository : JpaRepository<RefreshToken, Long>
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
+    fun findByToken(token: String): RefreshToken?
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/TokenProvider.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/contract/TokenProvider.kt
@@ -1,5 +1,8 @@
 package com.localtalk.api.auth.domain.contract
 
+import com.localtalk.api.auth.domain.AuthMember
+
 interface TokenProvider {
     fun generateToken(id: Long, role: String): Pair<String, String>
+    fun parseToken(token: String): AuthMember
 }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/service/TokenService.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/domain/service/TokenService.kt
@@ -6,6 +6,7 @@ import com.localtalk.api.auth.domain.RefreshToken
 import com.localtalk.api.auth.domain.contract.RefreshTokenRepository
 import com.localtalk.api.auth.domain.contract.TokenProvider
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TokenService(
@@ -16,6 +17,18 @@ class TokenService(
     fun generateToken(id: Long, authRole: AuthRole): LoginToken {
         return tokenProvider.generateToken(id, authRole.name)
             .also { (_, refreshToken) -> refreshTokenRepository.save(RefreshToken(refreshToken)) }
+            .let { (accessToken, refreshToken) -> LoginToken(accessToken, refreshToken) }
+    }
+
+    @Transactional
+    fun rotateRefreshToken(refreshToken: String): LoginToken {
+        val token = refreshTokenRepository.findByToken(refreshToken)
+            ?: throw IllegalArgumentException("존재하지 않는 토큰입니다.")
+
+        val authMember = tokenProvider.parseToken(token.token)
+
+        return tokenProvider.generateToken(authMember.id, authMember.role.name)
+            .also { (_, refreshToken) -> token.update(refreshToken) }
             .let { (accessToken, refreshToken) -> LoginToken(accessToken, refreshToken) }
     }
 

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/AuthController.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/AuthController.kt
@@ -1,0 +1,32 @@
+package com.localtalk.api.auth.entrypoint
+
+import com.localtalk.api.auth.application.TokenApplicationService
+import com.localtalk.api.auth.entrypoint.document.AuthApi
+import com.localtalk.api.auth.entrypoint.dto.TokenRefreshRequest
+import com.localtalk.api.auth.entrypoint.dto.TokenRefreshResponse
+import com.localtalk.api.auth.entrypoint.mapper.AuthRestMapper
+import com.localtalk.common.model.RestResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    val tokenApplicationService: TokenApplicationService,
+    val authRestMapper: AuthRestMapper,
+) : AuthApi {
+
+    @PostMapping("/refresh")
+    override fun rotateRefreshToken(
+        @RequestBody request: TokenRefreshRequest,
+    ): ResponseEntity<RestResponse<TokenRefreshResponse>> {
+        return authRestMapper.toCommand(request)
+            .let { command -> tokenApplicationService.rotateRefreshToken(command) }
+            .let { info -> authRestMapper.toResponse(info) }
+            .let { response -> RestResponse.success(response, "토큰이 성공적으로 갱신되었습니다") }
+            .let { ResponseEntity.ok(it) }
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/document/AuthApi.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/document/AuthApi.kt
@@ -1,0 +1,80 @@
+package com.localtalk.api.auth.entrypoint.document
+
+import com.localtalk.api.auth.entrypoint.dto.TokenRefreshRequest
+import com.localtalk.api.auth.entrypoint.dto.TokenRefreshResponse
+import com.localtalk.common.model.RestResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "인증 관리", description = "토큰 갱신 및 인증 관련 API")
+interface AuthApi {
+
+    @Operation(
+        summary = "리프레시 토큰 갱신",
+        description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다. 기존 리프레시 토큰은 새로운 토큰으로 업데이트됩니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200", 
+                description = "토큰 갱신 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    examples = [ExampleObject(
+                        name = "성공 응답",
+                        value = "{\"code\":200,\"data\":{\"access_token\":\"eyJhbGci...\",\"refresh_token\":\"eyJhbGci...\"},\"message\":\"토큰이 성공적으로 갱신되었습니다\"}"
+                    )]
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400", 
+                description = "잘못된 요청",
+                content = [Content(
+                    mediaType = "application/json",
+                    examples = [
+                        ExampleObject(
+                            name = "리프레시 토큰 누락",
+                            value = "{\"code\":400,\"data\":{},\"message\":\"리프레시 토큰을 입력해주세요\"}"
+                        ),
+                        ExampleObject(
+                            name = "빈 리프레시 토큰",
+                            value = "{\"code\":400,\"data\":{},\"message\":\"유효한 리프레시 토큰을 입력해주세요\"}"
+                        ),
+                        ExampleObject(
+                            name = "존재하지 않는 토큰",
+                            value = "{\"code\":400,\"data\":{},\"message\":\"존재하지 않는 토큰입니다.\"}"
+                        ),
+                        ExampleObject(
+                            name = "만료된 토큰",
+                            value = "{\"code\":400,\"data\":{},\"message\":\"만료된 토큰입니다.\"}"
+                        ),
+                        ExampleObject(
+                            name = "잘못된 요청 형식",
+                            value = "{\"code\":400,\"data\":{},\"message\":\"잘못된 요청 형식입니다.\"}"
+                        )
+                    ]
+                )]
+            ),
+            ApiResponse(
+                responseCode = "500", 
+                description = "서버 내부 오류",
+                content = [Content(
+                    mediaType = "application/json",
+                    examples = [ExampleObject(
+                        name = "서버 내부 오류",
+                        value = "{\"code\":500,\"data\":{},\"message\":\"서버 내부 오류가 발생했습니다.\"}"
+                    )]
+                )]
+            )
+        ]
+    )
+    fun rotateRefreshToken(
+        @RequestBody request: TokenRefreshRequest
+    ): ResponseEntity<RestResponse<TokenRefreshResponse>>
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/dto/TokenRefreshRequest.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/dto/TokenRefreshRequest.kt
@@ -1,0 +1,17 @@
+package com.localtalk.api.auth.entrypoint.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "리프레시 토큰 갱신 요청")
+data class TokenRefreshRequest(
+    @field:Schema(
+        description = "갱신할 리프레시 토큰",
+        example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        required = true
+    )
+    val refreshToken: String?
+) {
+    init {
+        require(refreshToken != null) { "리프레시 토큰을 입력해주세요" }
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/dto/TokenRefreshResponse.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/dto/TokenRefreshResponse.kt
@@ -1,0 +1,18 @@
+package com.localtalk.api.auth.entrypoint.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "리프레시 토큰 갱신 응답")
+data class TokenRefreshResponse(
+    @field:Schema(
+        description = "새로 발급된 액세스 토큰",
+        example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXV0aFJvbGUiOiJNRU1CRVIiLCJpYXQiOjE3MDMxNjk2MDAsImV4cCI6MTcwMzE3MzIwMH0.new_access_token_signature"
+    )
+    val accessToken: String,
+
+    @field:Schema(
+        description = "업데이트된 리프레시 토큰 (기존 토큰이 갱신됨)",
+        example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidHlwZSI6InJlZnJlc2giLCJpYXQiOjE3MDMxNjk2MDAsImV4cCI6MTcwNDQ2NTYwMH0.updated_refresh_token_signature"
+    )
+    val refreshToken: String
+)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/mapper/AuthRestMapper.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/mapper/AuthRestMapper.kt
@@ -1,0 +1,24 @@
+package com.localtalk.api.auth.entrypoint.mapper
+
+import com.localtalk.api.auth.application.dto.RefreshTokenCommand
+import com.localtalk.api.auth.application.dto.TokenRefreshInfo
+import com.localtalk.api.auth.entrypoint.dto.TokenRefreshRequest
+import com.localtalk.api.auth.entrypoint.dto.TokenRefreshResponse
+import org.springframework.stereotype.Component
+
+@Component
+class AuthRestMapper {
+
+    fun toCommand(request: TokenRefreshRequest): RefreshTokenCommand {
+        return RefreshTokenCommand(
+            refreshToken = request.refreshToken!!
+        )
+    }
+
+    fun toResponse(info: TokenRefreshInfo): TokenRefreshResponse {
+        return TokenRefreshResponse(
+            accessToken = info.accessToken,
+            refreshToken = info.refreshToken
+        )
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenProvider.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenProvider.kt
@@ -10,7 +10,7 @@ import java.time.temporal.ChronoUnit
 @EnableConfigurationProperties(JwtProperties::class)
 class JwtTokenProvider(
     val jwtProperties: JwtProperties,
-    val clock: Clock = Clock.systemDefaultZone(),
+    val clock: Clock,
 ) : TokenProvider {
 
     val tokenHandler = JwtTokenHandler(jwtProperties.secret)
@@ -22,14 +22,14 @@ class JwtTokenProvider(
             id = id,
             role = role,
             issuedAt = now,
-            expiresAt = now.plus(jwtProperties.accessTokenExpiry, ChronoUnit.SECONDS)
+            expiresAt = now.plus(jwtProperties.accessTokenExpiry, ChronoUnit.SECONDS),
         )
 
         val refreshToken = tokenHandler.createToken(
             id = id,
             role = role,
             issuedAt = now,
-            expiresAt = now.plus(jwtProperties.refreshTokenExpiry, ChronoUnit.SECONDS)
+            expiresAt = now.plus(jwtProperties.refreshTokenExpiry, ChronoUnit.SECONDS),
         )
 
         return accessToken to refreshToken

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenProvider.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenProvider.kt
@@ -1,5 +1,7 @@
 package com.localtalk.api.auth.infrastructure.token
 
+import com.localtalk.api.auth.domain.AuthMember
+import com.localtalk.api.auth.domain.AuthRole
 import com.localtalk.api.auth.domain.contract.TokenProvider
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
@@ -33,5 +35,14 @@ class JwtTokenProvider(
         )
 
         return accessToken to refreshToken
+    }
+
+
+    override fun parseToken(token: String): AuthMember {
+        val claims = tokenHandler.parseToken(token)
+        val id = (claims[ID_CLAIM] as Number).toLong()
+        val role = claims.get(ROLE_CLAIM, String::class.java)
+
+        return AuthMember(id, AuthRole.valueOf(role))
     }
 }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/common/exception/GlobalExceptionHandler.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/common/exception/GlobalExceptionHandler.kt
@@ -70,8 +70,8 @@ class GlobalExceptionHandler {
             .body(RestResponse.error(HttpStatus.BAD_REQUEST, message))
     }
 
-    @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<RestResponse<Unit>> {
+    @ExceptionHandler(IllegalArgumentException::class, IllegalStateException::class)
+    fun handleIllegalArgumentException(e: Exception): ResponseEntity<RestResponse<Unit>> {
         log.debug("Invalid argument", e)
         return ResponseEntity
             .badRequest()

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/config/ClockConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/config/ClockConfig.kt
@@ -1,0 +1,12 @@
+package com.localtalk.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class ClockConfig {
+
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/application/dto/RefreshTokenCommandTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/application/dto/RefreshTokenCommandTest.kt
@@ -1,0 +1,16 @@
+package com.localtalk.api.auth.application.dto
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class RefreshTokenCommandTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   ", "\t", "\n"])
+    fun `빈 문자열 또는 공백 리프레시 토큰으로 객체 생성 시 예외를 발생시킨다`(invalidToken: String) {
+        assertThatThrownBy { RefreshTokenCommand(invalidToken) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("유효한 리프레시 토큰을 입력해주세요")
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/domain/service/TokenServiceTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/domain/service/TokenServiceTest.kt
@@ -1,0 +1,31 @@
+package com.localtalk.api.auth.domain.service
+
+import com.localtalk.api.auth.domain.contract.RefreshTokenRepository
+import com.localtalk.api.auth.domain.contract.TokenProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class TokenServiceTest {
+
+    private val tokenProvider = mockk<TokenProvider>()
+    private val refreshTokenRepository = mockk<RefreshTokenRepository>()
+    private val tokenService = TokenService(tokenProvider, refreshTokenRepository)
+
+    @Nested
+    inner class `리프레시 토큰을 전달했을 때` {
+
+        @Test
+        fun `해당 토큰 정보가 존재하지 않는 경우 IllegalArgumentException을 발생시킨다`() {
+            val nonExistentToken = "non_existent_token"
+            
+            every { refreshTokenRepository.findByToken(nonExistentToken) } returns null
+
+            assertThatThrownBy { tokenService.rotateRefreshToken(nonExistentToken) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("존재하지 않는 토큰입니다.")
+        }
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/AuthControllerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/AuthControllerTest.kt
@@ -1,0 +1,122 @@
+package com.localtalk.api.auth.entrypoint
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.localtalk.api.auth.infrastructure.token.JwtProperties
+import com.localtalk.api.support.IntegrationTest
+import com.localtalk.api.support.KakaoApiMockServer
+import com.localtalk.api.utils.JwtTestUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.returnResult
+
+class AuthControllerTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var jwtProperties: JwtProperties
+
+    @Nested
+    inner class `토큰 갱신 API를 호출할 때` {
+
+        @Test
+        fun `유효한 리프레시 토큰을 전달하면 토큰을 재발급 받는다`() {
+            KakaoApiMockServer.enqueueSuccessResponse()
+
+            val loginResponse = webTestClient.post()
+                .uri("/api/v1/social-logins/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"access_token":"valid_kakao_access_token"}""")
+                .exchange()
+                .expectStatus().isOk
+                .returnResult<JsonNode>()
+                .responseBody
+                .blockFirst()!!
+
+            val accessToken = loginResponse["data"]["access_token"].asText()
+            val refreshToken = loginResponse["data"]["refresh_token"].asText()
+
+            val response = webTestClient.mutate()
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+                .build()
+                .post()
+                .uri("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"refresh_token":"$refreshToken"}""")
+                .exchange()
+                .expectStatus().isOk
+                .returnResult<JsonNode>()
+                .responseBody
+                .blockFirst()!!
+
+            assertThat(response["code"].asInt()).isEqualTo(200)
+            assertThat(response["message"].asText()).isEqualTo("토큰이 성공적으로 갱신되었습니다")
+
+            val newAccessToken = response["data"]["access_token"].asText()
+            val newRefreshToken = response["data"]["refresh_token"].asText()
+
+            assertThat(JwtTestUtils.isValidJwtFormat(newAccessToken)).isTrue()
+            assertThat(JwtTestUtils.isValidJwtFormat(newRefreshToken)).isTrue()
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                """{}""",
+                """{"refresh_token":null}""",
+            ],
+        )
+        fun `잘못된 리프레시 토큰으로 요청하면 400 에러를 반환한다`(requestBody: String) {
+            webTestClient.post()
+                .uri("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("리프레시 토큰을 입력해주세요")
+        }
+
+        @Test
+        fun `리프레시 토큰 값을 빈 값으로 요청하면 400 에러를 반환한다`() {
+            webTestClient.post()
+                .uri("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"refresh_token":""}""")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("유효한 리프레시 토큰을 입력해주세요")
+        }
+
+        @Test
+        fun `만료된 리프레시 토큰으로 요청하면 400 에러를 반환한다`() {
+            clock.minusSeconds(jwtProperties.refreshTokenExpiry + 1)
+            KakaoApiMockServer.enqueueSuccessResponse()
+            val loginResponse = webTestClient.post()
+                .uri("/api/v1/social-logins/kakao")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"access_token":"valid_kakao_access_token"}""")
+                .exchange()
+                .expectStatus().isOk
+                .returnResult<JsonNode>()
+                .responseBody
+                .blockFirst()!!
+
+            val refreshToken = loginResponse["data"]["refresh_token"].asText()
+
+            webTestClient.post()
+                .uri("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"refresh_token":"$refreshToken"}""")
+                .exchange()
+                .expectStatus().isBadRequest
+                .expectBody()
+                .jsonPath("$.message").isEqualTo("만료된 토큰입니다.")
+        }
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/SocialLoginControllerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/SocialLoginControllerTest.kt
@@ -1,7 +1,7 @@
 package com.localtalk.api.auth.entrypoint
 
-import com.localtalk.api.config.KakaoApiMockServer
 import com.localtalk.api.support.IntegrationTest
+import com.localtalk.api.support.KakaoApiMockServer
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/dto/TokenRefreshRequestTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/entrypoint/dto/TokenRefreshRequestTest.kt
@@ -1,0 +1,22 @@
+package com.localtalk.api.auth.entrypoint.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class TokenRefreshRequestTest {
+
+    @Test
+    fun `유효한 리프레시 토큰으로 객체를 생성한다`() {
+        val want = TokenRefreshRequest("valid_refresh_token")
+
+        assertThat(want.refreshToken).isEqualTo("valid_refresh_token")
+    }
+
+    @Test
+    fun `null 리프레시 토큰으로 객체 생성 시 예외를 발생시킨다`() {
+        assertThatThrownBy { TokenRefreshRequest(null) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("리프레시 토큰을 입력해주세요")
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenHandlerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/auth/infrastructure/token/JwtTokenHandlerTest.kt
@@ -1,0 +1,65 @@
+package com.localtalk.api.auth.infrastructure.token
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class JwtTokenHandlerTest {
+
+    val secretKey = "test-secret-key-for-jwt-token-generation-must-be-long-enough-for-hmac-sha256"
+    val jwtTokenHandler = JwtTokenHandler(secretKey)
+
+    @Nested
+    inner class `토큰을 생성할 때` {
+
+        @Test
+        fun `유효한 토큰이 생성된다`() {
+            val id = 123L
+            val role = "MEMBER"
+            val now = Instant.now()
+            val expiresAt = now.plusSeconds(3600)
+
+            val token = jwtTokenHandler.createToken(id, role, now, expiresAt)
+
+            assertThat(token).isNotBlank()
+            assertThat(token.split(".")).hasSize(3)
+        }
+    }
+
+    @Nested
+    inner class `유효한 토큰을 파싱할 때` {
+
+        @Test
+        fun `Claims가 정상적으로 반환된다`() {
+            val id = 123L
+            val role = "MEMBER"
+            val now = Instant.now()
+            val expiresAt = now.plusSeconds(3600)
+            val token = jwtTokenHandler.createToken(id, role, now, expiresAt)
+
+            val claims = jwtTokenHandler.parseToken(token)
+
+            assertThat(claims.get(ID_CLAIM, Number::class.java).toLong()).isEqualTo(id)
+            assertThat(claims.get(ROLE_CLAIM, String::class.java)).isEqualTo(role)
+        }
+    }
+
+    @Nested
+    inner class `만료된 토큰을 파싱할 때` {
+
+        @Test
+        fun `IllegalStateException을 발생시킨다`() {
+            val id = 123L
+            val role = "MEMBER"
+            val now = Instant.now()
+            val pastTime = now.minusSeconds(3600) // 1시간 전 만료
+            val expiredToken = jwtTokenHandler.createToken(id, role, pastTime.minusSeconds(3600), pastTime)
+
+            assertThatThrownBy { jwtTokenHandler.parseToken(expiredToken) }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessage("만료된 토큰입니다.")
+        }
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/IntegrationTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/IntegrationTest.kt
@@ -1,7 +1,6 @@
 package com.localtalk.api.support
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.localtalk.api.config.KakaoApiMockServer
 import com.localtalk.config.MysqlTestContainerConfig
 import com.localtalk.utils.JpaDatabaseCleaner
 import org.junit.jupiter.api.AfterEach
@@ -16,7 +15,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.returnResult
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(MysqlTestContainerConfig::class, KakaoApiMockServer::class)
+@Import(MysqlTestContainerConfig::class, KakaoApiMockServer::class, TestClockConfig::class)
 @AutoConfigureWebTestClient
 @ActiveProfiles("test")
 abstract class IntegrationTest {
@@ -27,9 +26,13 @@ abstract class IntegrationTest {
     @Autowired
     protected lateinit var databaseCleaner: JpaDatabaseCleaner
 
+    @Autowired
+    protected lateinit var clock: MutableClock
+
     @AfterEach
     fun tearDown() {
         databaseCleaner.truncateAllTables()
+        clock.now()
     }
 
     fun loginAsTemporaryMember(): WebTestClient {

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/KakaoApiMockServer.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/KakaoApiMockServer.kt
@@ -1,4 +1,4 @@
-package com.localtalk.api.config
+package com.localtalk.api.support
 
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/MutableClock.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/MutableClock.kt
@@ -1,0 +1,28 @@
+package com.localtalk.api.support
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class MutableClock(
+    private var current: Instant,
+    private val zone: ZoneId = ZoneOffset.UTC,
+) : Clock() {
+
+    override fun withZone(zone: ZoneId): Clock = MutableClock(current, zone)
+    override fun getZone(): ZoneId = zone
+    override fun instant(): Instant = current
+
+    fun now() {
+        this.current = Instant.now()
+    }
+
+    fun set(instant: Instant) {
+        current = instant
+    }
+
+    fun minusSeconds(sec: Long) {
+        current = current.minusSeconds(sec)
+    }
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/TestClockConfig.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/TestClockConfig.kt
@@ -1,0 +1,14 @@
+package com.localtalk.api.support
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import java.time.Instant
+
+@TestConfiguration
+class TestClockConfig {
+
+    @Bean
+    @Primary
+    fun testClock(): MutableClock = MutableClock(Instant.now())
+}

--- a/http/auth.http
+++ b/http/auth.http
@@ -1,0 +1,21 @@
+### 토큰 갱신 API 테스트
+
+@baseUrl = http://localhost:8080
+
+### 소셜 로그인 (토큰 발급)
+POST {{baseUrl}}/api/v1/social-logins/kakao
+Content-Type: application/json
+
+{
+  "access_token": "카카오 로그인 토큰"
+}
+
+> {% client.global.set("refresh_token", response.body.data.refresh_token); %}
+
+### 토큰 갱신
+POST {{baseUrl}}/api/v1/auth/refresh
+Content-Type: application/json
+
+{
+  "refresh_token": "{{refresh_token}}"
+}

--- a/http/nickname-validation.http
+++ b/http/nickname-validation.http
@@ -7,7 +7,7 @@ POST {{baseUrl}}/api/v1/social-logins/kakao
 Content-Type: application/json
 
 {
-  "access_token": "IswGOP44exY8ttMaF_TNGG7OsLqHjKgVAAAAAQoNG5oAAAGYzPdATSEj9baI01p6"
+  "access_token": "카카오 액세스 토큰"
 }
 
 > {% client.global.set("auth_token", response.body.data.access_token); %}


### PR DESCRIPTION
## PR 설명

- [♻️ refactor : 유효한 상태가 아닌 경우 400에러를 내리도록 예외 핸들러 설정 추가](https://github.com/local-talk/local-talk-BE/commit/38d901cda5ac45ffd4d22de7efd5ed906e9d8a76)
    - JWT 토큰 파싱 중 발생하는 IllegalStateException을 GlobalExceptionHandler에서 400 Bad Request로 처리하도록 추가했습니다.
    - 만료된 토큰이나 잘못된 형식의 토큰에 대한 일관된 예외 응답을 제공합니다.
- [♻️ refactor : 시간값 테스트를 위해 Clock Bean 등록 및 테스트용 Clock 설정 추가](https://github.com/local-talk/local-talk-BE/commit/91b86b6fe44ad4fd7df097bdc1a44d4d5468d95a)
    - JWT 토큰 만료 테스트를 위해 Clock Bean을 추가하고 MutableClock을 통해 시간을 조작할 수 있도록 구현했습니다.
    - TestClockConfig를 통해 테스트 환경에서는 시간 조작이 가능한 MutableClock을 사용하도록 설정했습니다.
- [🚚 refactor : 사용하지 않는 JWT 클레임 정보 파싱 후 Principal 등록 로직 제거](https://github.com/local-talk/local-talk-BE/commit/9ef6fa444d9f4106509b23138f3416850c48156d)
    - SecurityConfig를 간소화하여 Spring Security의 기본 JWT 설정을 사용하도록 변경했습니다.
- [✨ feat : 리프레시 토큰 갱신(RTR) 기능 구현](https://github.com/local-talk/local-talk-BE/commit/06393fbc0915529a8a7475af6805be1b7a347d47)
  -  POST /api/v1/auth/refresh API를 통해 Refresh Token Rotation(RTR) 기능을 구현했습니다.
  - 기존 토큰 무효화 후 새로운 토큰 쌍을 발급합니다. 
## 작업 내용

- [x] 리프레시 토큰을 이용하여 토큰을 재발급 받는 기능 구현
- [x] 시간 테스트를 위해 Clock 설정 및 테스트용 Clock 객체 구현
- [x] 예외 핸들링시 IllegalStateException도 400에러를 내리도록 수정
- [x] 사용하지 않는 Principal 설정 제거하여 Security 설정 간소화   


## 리뷰 포인트

<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    리뷰 받고 싶은 코드가 있다면 해당 코드에 대해 코멘트를 달아주시면 좋습니다. 
-->

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->