### PR TITLE
♻️ refactor : Swagger 문서 개선

### DIFF
--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
@@ -13,11 +13,13 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
     val jwtTokenDecoder: JwtTokenDecoder,
+    val corsConfigurationSource: CorsConfigurationSource,
 ) {
 
     @Bean
@@ -38,6 +40,7 @@ class SecurityConfig(
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         return http
+            .cors { it.configurationSource(corsConfigurationSource) }
             .csrf { it.disable() }
             .httpBasic { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/document/SocialLoginApi.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/entrypoint/document/SocialLoginApi.kt
@@ -5,6 +5,8 @@ import com.localtalk.api.auth.entrypoint.dto.SocialLoginResponse
 import com.localtalk.common.model.RestResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -17,18 +19,81 @@ interface SocialLoginApi {
 
     @Operation(
         summary = "소셜 로그인",
-        description = "카카오, 애플 등 소셜 로그인 프로바이더를 통한 로그인 처리",
+        description = "카카오, 애플 등 소셜 로그인 프로바이더를 통한 로그인을 처리합니다. " +
+                "클라이언트에서 획득한 액세스 토큰을 검증하여 애플리케이션 전용 토큰을 발급합니다. " +
+                "지원 프로바이더: kakao, apple",
+        security = [],
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "소셜 로그인 성공"),
-            ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+            ApiResponse(
+                responseCode = "200",
+                description = "소셜 로그인 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "기존 회원 로그인 성공",
+                                description = "이미 가입된 회원의 로그인 성공",
+                                value = "{\"code\":200,\"data\":{\"access_token\":\"eyJhbGci...\",\"refresh_token\":\"eyJhbGci...\",\"is_new_user\":false},\"message\":\"소셜 로그인이 성공했습니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "신규 회원 가입 및 로그인 성공",
+                                description = "새로운 회원의 가입 및 로그인 성공",
+                                value = "{\"code\":200,\"data\":{\"access_token\":\"eyJhbGci...\",\"refresh_token\":\"eyJhbGci...\",\"is_new_user\":true},\"message\":\"소셜 로그인이 성공했습니다\"}",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "지원하지 않는 프로바이더",
+                                description = "kakao, apple 이외의 프로바이더 요청시",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"지원하지 않는 소셜 로그인 프로바이더입니다: google\"}",
+                            ),
+                            ExampleObject(
+                                name = "액세스 토큰 누락",
+                                description = "요청에 액세스 토큰이 포함되지 않은 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"액세스 토큰을 입력해주세요.\"}",
+                            ),
+                            ExampleObject(
+                                name = "유효하지 않은 액세스 토큰",
+                                description = "프로바이더에서 토큰 검증에 실패한 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"유효하지 않은 액세스 토큰입니다\"}",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 내부 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "서버 오류",
+                                description = "예상치 못한 서버 내부 오류 발생",
+                                value = "{\"code\":500,\"data\":{},\"message\":\"서버 내부 오류가 발생했습니다.\"}",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
         ],
     )
     suspend fun socialLogin(
         @Parameter(
-            description = "소셜 로그인 프로바이더 (kakao, apple)",
+            description = "소셜 로그인 프로바이더",
             example = "kakao",
             required = true,
         )

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/config/CorsConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/config/CorsConfig.kt
@@ -1,0 +1,26 @@
+package com.localtalk.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+class CorsConfig {
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+
+        configuration.allowedOriginPatterns = listOf("*")
+        configuration.allowedMethods = listOf("*")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+
+        return source
+    }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/config/SwaggerConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/config/SwaggerConfig.kt
@@ -1,7 +1,10 @@
 package com.localtalk.api.config
 
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -17,6 +20,25 @@ class SwaggerConfig {
                     .title("Local Talk API")
                     .description("Local Talk 백엔드 API 문서")
                     .version("1.0.0"),
+            )
+            .addSecurityItem(
+                SecurityRequirement().addList("bearerAuth"),
+            )
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        "bearerAuth",
+                        SecurityScheme()
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")
+                            .description("JWT 토큰을 입력하세요 (Bearer 제외)"),
+                    ),
+            )
+            .addServersItem(
+                Server()
+                    .url("https://localtalk.site")
+                    .description("운영 서버"),
             )
             .addServersItem(
                 Server()

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/member/entrypoint/document/NicknameValidationApi.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/member/entrypoint/document/NicknameValidationApi.kt
@@ -3,6 +3,8 @@ package com.localtalk.api.member.entrypoint.document
 import com.localtalk.api.member.entrypoint.dto.NicknameValidationRequest
 import com.localtalk.common.model.RestResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -14,22 +16,90 @@ interface NicknameValidationApi {
 
     @Operation(
         summary = "닉네임 유효성 검증",
-        description = """
-            닉네임의 형식과 중복 여부를 검증합니다.
-            
-            ## 검증 규칙
-            - **길이**: 2자 이상 12자 이하
-            - **허용 문자**: 한글, 영문, 숫자, 공백, 언더스코어(_)
-            - **위치 제약**: 공백이나 _로 시작/끝날 수 없음
-            - **연속 제약**: 공백이나 _를 연속으로 사용할 수 없음
-            - **중복 검증**: 이미 다른 회원이 사용 중인 닉네임은 사용 불가
-        """,
+        description = "회원가입 시 사용할 닉네임의 형식과 중복 여부를 검증합니다. " +
+            "검증 규칙: 2-12자, 한글/영문/숫자/공백/언더스코어만 허용, " +
+            "공백이나 언더스코어로 시작/끝 불가, 연속 사용 불가, 중복 불가",
     )
     @ApiResponses(
         value = [
-            ApiResponse(responseCode = "200", description = "닉네임 검증 성공 (사용 가능한 닉네임)"),
-            ApiResponse(responseCode = "400", description = "닉네임 검증 실패 (형식 오류 또는 중복)"),
-            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+            ApiResponse(
+                responseCode = "200",
+                description = "닉네임 검증 성공 (사용 가능한 닉네임)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "검증 성공",
+                                description = "사용 가능한 닉네임",
+                                value = "{\"code\":200,\"data\":{},\"message\":\"닉네임 검증이 완료되었습니다\"}",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "닉네임 검증 실패",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "닉네임 누락",
+                                description = "닉네임이 전달되지 않은 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"닉네임은 필수입니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "길이 오류 - 너무 짧음",
+                                description = "2자 미만인 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"닉네임은 2자 이상 12자 이하여야 합니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "길이 오류 - 너무 김",
+                                description = "12자 초과인 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"닉네임은 2자 이상 12자 이하여야 합니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "허용되지 않는 문자",
+                                description = "특수문자 등 허용되지 않는 문자 포함",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"닉네임은 한글, 영문, 숫자, 공백, _만 사용 가능합니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "잘못된 시작/끝 문자",
+                                description = "공백이나 _로 시작하거나 끝나는 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"닉네임은 공백이나 _로 시작할 수 없습니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "연속 특수문자",
+                                description = "공백이나 _를 연속으로 사용한 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"닉네임에 공백이나 _를 연속으로 사용할 수 없습니다\"}",
+                            ),
+                            ExampleObject(
+                                name = "중복된 닉네임",
+                                description = "이미 사용 중인 닉네임인 경우",
+                                value = "{\"code\":400,\"data\":{},\"message\":\"이미 사용 중인 닉네임입니다\"}",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 내부 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        examples = [
+                            ExampleObject(
+                                name = "서버 오류",
+                                description = "예상치 못한 서버 내부 오류 발생",
+                                value = "{\"code\":500,\"data\":{},\"message\":\"서버 내부 오류가 발생했습니다.\"}",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
         ],
     )
     fun validateNickname(


### PR DESCRIPTION
## PR 설명
- [♻️ refactor : 문서 내용을 좀 더 명확하게 작성하도록 개선](https://github.com/local-talk/local-talk-BE/commit/6f9f074c9d680e3e6d12c3fcd508ba8aee6f3599)
  - API 문서 내용에 잘못된 응답 형식(실패가 응답과 동일한 형식으로 보임)이나 실패시에 대한 상세한 내용이 부족하여 읽는사람이 이해하기 어렵다는 것을 인지했습니다.
  - 읽는 사람 입장에서 어떤 문제가 발생할 수 있는지, 어떤 값들을 기대하는지 좀 더 상세하게 예시를 제공하여 이해하기 쉽도록 개선했습니다.
- [🔧 config : JWT 인증이 필요한 API에 대해 인증 강제 추가](https://github.com/local-talk/local-talk-BE/commit/9992c64564a9a84eeb2bdbf1d143978ca7d32ff7)
  - 인증이 필요한 API에 대해 JWT 토큰을 헤더에 추가하는 기능을 만들었습니다.
  - 사용자가 직접 인증받은 토큰을 입력하여 인증된 API도 문제없이 테스트가 가능합니다.
-  [🔧 config : 스웨거 사용중 로컬에서 운영서버 테스트하기 위해 CORS 설정 추가](https://github.com/local-talk/local-talk-BE/commit/3151e630732b60e4df7ea86691c0d571a2e78b19)
   - 스웨거 사용중 로컬에서 운영으로 테스트하는 경우 CORS에러가 발생하여 CORS를 풀어두었습니다. 앱에서는 CORS 설정이 별도로 필요하지는 않으나 편의를 위해 전체 Origin을 푸는 방식으로 진행했습니다. 

## 작업 내용

- [x] 응답 포맷을 정확하게 변경 및 다양한 응답에 대한 예시 추가
- [x] 테스트시 JWT 인증 토큰을 헤더에 추가할 수 있도록 설정 추가
- [x] CORS 설정 추가
