### PR TITLE
:sparkles: feat : 관심사 조회 기능 구현

### DIFF
--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/auth/config/SecurityConfig.kt
@@ -35,6 +35,7 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/social-logins/**").permitAll()
                     .requestMatchers("/api/v1/districts/**").permitAll()
                     .requestMatchers("/api/v1/auth/refresh").permitAll()
+                    .requestMatchers("/api/v1/interests/**").permitAll()
                     .requestMatchers("/api/v1/members/nickname/validate").authenticated()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/api/v1/**").hasRole(AuthRole.MEMBER.name)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/application/InterestApplicationService.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/application/InterestApplicationService.kt
@@ -1,0 +1,16 @@
+package com.localtalk.api.interest.application
+
+import com.localtalk.api.interest.application.dto.InterestInfo
+import com.localtalk.api.interest.application.mapper.InterestApplicationMapper
+import com.localtalk.api.interest.domain.InterestService
+import org.springframework.stereotype.Service
+
+@Service
+class InterestApplicationService(
+    val interestService: InterestService,
+    val interestApplicationMapper: InterestApplicationMapper,
+) {
+    fun findAllInterests(): List<InterestInfo> =
+        interestService.findAllInterests()
+            .let { interestApplicationMapper.toInterestInfos(it) }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/application/dto/InterestInfo.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/application/dto/InterestInfo.kt
@@ -1,0 +1,7 @@
+package com.localtalk.api.interest.application.dto
+
+data class InterestInfo(
+    val id: Long,
+    val name: String,
+    val emoji: String,
+)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/application/mapper/InterestApplicationMapper.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/application/mapper/InterestApplicationMapper.kt
@@ -1,0 +1,19 @@
+package com.localtalk.api.interest.application.mapper
+
+import com.localtalk.api.interest.application.dto.InterestInfo
+import com.localtalk.api.interest.domain.Interest
+import org.springframework.stereotype.Component
+
+@Component
+class InterestApplicationMapper {
+
+    fun toInterestInfos(interests: List<Interest>): List<InterestInfo> =
+        interests.map { toInterestInfo(it) }
+
+    fun toInterestInfo(interest: Interest): InterestInfo =
+        InterestInfo(
+            id = interest.id,
+            name = interest.name,
+            emoji = interest.emoji,
+        )
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/domain/Interest.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/domain/Interest.kt
@@ -1,0 +1,23 @@
+package com.localtalk.api.interest.domain
+
+import com.localtalk.domain.SoftDeleteBaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.Comment
+
+@Entity
+@Table(name = "interest")
+class Interest(
+    @Column(name = "name", nullable = false, length = 50)
+    @Comment("관심사 이름")
+    val name: String,
+
+    @Column(name = "emoji", nullable = false, length = 10)
+    @Comment("관심사 이모지")
+    val emoji: String,
+
+    @Column(name = "display_order", nullable = false, unique = true)
+    @Comment("표시 순서")
+    val displayOrder: Int,
+) : SoftDeleteBaseEntity()

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/domain/InterestRepository.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/domain/InterestRepository.kt
@@ -1,0 +1,7 @@
+package com.localtalk.api.interest.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InterestRepository : JpaRepository<Interest, Long> {
+    fun findAllByDeletedAtIsNullOrderByDisplayOrder(): List<Interest>
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/domain/InterestService.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/domain/InterestService.kt
@@ -1,0 +1,11 @@
+package com.localtalk.api.interest.domain
+
+import org.springframework.stereotype.Service
+
+@Service
+class InterestService(
+    val interestRepository: InterestRepository,
+) {
+    fun findAllInterests(): List<Interest> =
+        interestRepository.findAllByDeletedAtIsNullOrderByDisplayOrder()
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/InterestController.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/InterestController.kt
@@ -1,0 +1,22 @@
+package com.localtalk.api.interest.entrypoint
+
+import com.localtalk.api.interest.application.InterestApplicationService
+import com.localtalk.api.interest.entrypoint.document.InterestApi
+import com.localtalk.api.interest.entrypoint.dto.InterestResponse
+import com.localtalk.api.interest.entrypoint.mapper.InterestRestMapper
+import com.localtalk.common.model.RestResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class InterestController(
+    val interestApplicationService: InterestApplicationService,
+    val interestRestMapper: InterestRestMapper,
+) : InterestApi {
+
+    override fun findAllInterests(): ResponseEntity<RestResponse<List<InterestResponse>>> =
+        interestApplicationService.findAllInterests()
+            .let { interestRestMapper.toResponses(it) }
+            .let { RestResponse.success(it, "관심사 목록 조회가 완료되었습니다") }
+            .let { ResponseEntity.ok(it) }
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/document/InterestApi.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/document/InterestApi.kt
@@ -1,0 +1,28 @@
+package com.localtalk.api.interest.entrypoint.document
+
+import com.localtalk.api.interest.entrypoint.dto.InterestResponse
+import com.localtalk.common.model.RestResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "관심사", description = "관심사 관련 API")
+@RequestMapping("/api/v1/interests")
+interface InterestApi {
+
+    @Operation(
+        summary = "관심사 목록 조회",
+        description = "등록된 모든 관심사를 표시 순서대로 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "관심사 목록 조회 성공"),
+        ],
+    )
+    @GetMapping
+    fun findAllInterests(): ResponseEntity<RestResponse<List<InterestResponse>>>
+}

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/dto/InterestResponse.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/dto/InterestResponse.kt
@@ -1,0 +1,7 @@
+package com.localtalk.api.interest.entrypoint.dto
+
+data class InterestResponse(
+    val id: Long,
+    val name: String,
+    val emoji: String,
+)

--- a/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/mapper/InterestRestMapper.kt
+++ b/apps/localtalk-api/src/main/kotlin/com/localtalk/api/interest/entrypoint/mapper/InterestRestMapper.kt
@@ -1,0 +1,19 @@
+package com.localtalk.api.interest.entrypoint.mapper
+
+import com.localtalk.api.interest.application.dto.InterestInfo
+import com.localtalk.api.interest.entrypoint.dto.InterestResponse
+import org.springframework.stereotype.Component
+
+@Component
+class InterestRestMapper {
+
+    fun toResponses(interestInfos: List<InterestInfo>): List<InterestResponse> =
+        interestInfos.map { toResponse(it) }
+
+    fun toResponse(interestInfo: InterestInfo): InterestResponse =
+        InterestResponse(
+            id = interestInfo.id,
+            name = interestInfo.name,
+            emoji = interestInfo.emoji,
+        )
+}

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/interest/entrypoint/InterestControllerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/interest/entrypoint/InterestControllerTest.kt
@@ -1,0 +1,40 @@
+package com.localtalk.api.interest.entrypoint
+
+import com.localtalk.api.interest.domain.Interest
+import com.localtalk.api.interest.domain.InterestRepository
+import com.localtalk.api.support.IntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class InterestControllerTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var interestRepository: InterestRepository
+
+    @Test
+    fun `관심사 목록을 조회할 수 있다`() {
+        val interests = listOf(
+            Interest(name = "데이트", emoji = "💖", displayOrder = 1),
+            Interest(name = "자기계발", emoji = "📖", displayOrder = 2),
+            Interest(name = "쇼핑", emoji = "👕", displayOrder = 3),
+        )
+        interestRepository.saveAll(interests)
+
+        webTestClient.get()
+            .uri("/api/v1/interests")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.code").isEqualTo(200)
+            .jsonPath("$.message").isEqualTo("관심사 목록 조회가 완료되었습니다")
+            .jsonPath("$.data").isArray
+            .jsonPath("$.data.length()").isEqualTo(3)
+            .jsonPath("$.data[0].name").isEqualTo("데이트")
+            .jsonPath("$.data[0].emoji").isEqualTo("💖")
+            .jsonPath("$.data[1].name").isEqualTo("자기계발")
+            .jsonPath("$.data[1].emoji").isEqualTo("📖")
+            .jsonPath("$.data[2].name").isEqualTo("쇼핑")
+            .jsonPath("$.data[2].emoji").isEqualTo("👕")
+    }
+
+}


### PR DESCRIPTION
## PR 설명

- [✨ feat : 관심사 조회 기능 구현](https://github.com/local-talk/local-talk-BE/commit/b54ead60c2326a4e7d3b6ba5620c51722d7183b5)
  - 회원가입시 사용되는 관심사 조회 기능을 구현했습니다.
  - 관심사 정보 목록을 프론트엔드 전역에서 쓸수도 있기 때문에 PermitAll로 누구나 호출 가능하게(익명 사용자도) 처리했습니다.
  - 아직 데이터는 넣지 않았으며, 차후 관심사가 확정되고 flyway 도입하면서 추가할 예정입니다.
  - displayOrder를 통해 표시순서를 정렬해서 전달합니다. 서버에서 해당 정보로 정렬하기 때문에 클라이언트에는 전달하지 않습니다. 
  - 이모지와 이름을 분리하여 회원가입창에서는 합치고, 필터등에서는 이름만 사용할 수 있도록 구현했습니다.
## 작업 내용

- [x] 관심사 조회 기능 구현
