### PR TITLE
:wrench: config : 빌드버전을 깃 커밋 해시로 설정하도록 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.gradle.kotlin.dsl.withType
+import org.gradle.api.Project.DEFAULT_VERSION
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -12,10 +12,22 @@ plugins {
     alias(libs.plugins.spring.dependency.management) apply false
 }
 
+
+fun getGitHash(): String {
+    return runCatching {
+        providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+            .standardOutput
+            .asText
+            .get()
+            .trim()
+    }.getOrElse { "init" }
+}
+
+
 allprojects {
     val projectGroup: String by project
     group = projectGroup
-    version = "0.0.1-SNAPSHOT"
+    version = if (version == DEFAULT_VERSION) getGitHash() else version
 
     repositories {
         mavenCentral()
@@ -50,6 +62,7 @@ subprojects {
         project.path.startsWith(":apps:") -> {
             tasks.withType<BootJar> { enabled = true }
         }
+
         else -> {
             tasks.withType<BootJar> { enabled = false }
         }


### PR DESCRIPTION
## PR 설명
- [🔧 config : 빌드버전을 깃 커밋 해시로 설정하도록 변경](https://github.com/local-talk/local-talk-BE/commit/42db1b87f2cc366c83bbf275b7fa4dcb69131b0e)
  - 현재 항상 같은 버전으로(0.0.1-SNAPSHOT) 빌드하기 때문에 jar파일이 어떤 버전인지 알기 어렵습니다.
  - git hash로 버전을 설정해 현재 어떤 커밋의 jar 파일인지 명확하게 알 수 있도록 구현했습니다. 

## 작업 내용
- [x] 빌드버전을 깃 커밋 해시로 설정하도록 변경

## 리뷰 포인트

<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    리뷰 받고 싶은 코드가 있다면 해당 코드에 대해 코멘트를 달아주시면 좋습니다. 
-->

## 참고 자료

<!--
  (Optional: 참고 자료가 없는 작업이라면 삭제해주세요)
  작업에 대한 참고자료(PR, 피그마, 슬랙 등)가 있는 경우 링크를 참고 자료에 같이 추가해주시면 좋을 것 같아요.
-->