### PR TITLE
♻️ refactor : 파일 업로드 테스트 구조 개선

### DIFF
--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/common/exception/GlobalExceptionHandlerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/common/exception/GlobalExceptionHandlerTest.kt
@@ -68,9 +68,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `지원하지 않는 HTTP 메서드 요청시 400 상태코드를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.post()
+            webTestClient.post()
                 .uri("/test-rest-api-exceptions/get-only")
                 .exchange()
                 .expectStatus().isBadRequest
@@ -82,9 +82,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `잘못된 Content-Type으로 요청시 400 상태코드를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.post()
+            webTestClient.post()
                 .uri("/test-rest-api-exceptions/post-only")
                 .contentType(MediaType.TEXT_PLAIN)
                 .bodyValue("plain text")
@@ -103,9 +103,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `잘못된 JSON 형식 요청시 400 상태코드와 형식 오류 메시지를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.post()
+            webTestClient.post()
                 .uri("/test-json-exceptions/validation-error")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue("{invalid json}")
@@ -119,9 +119,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `JSON 파싱 중 IllegalArgumentException 발생시 해당 예외 메시지를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.post()
+            webTestClient.post()
                 .uri("/test-json-exceptions/validation-error")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue("""{"validField": ""}""")
@@ -135,9 +135,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `JSON 파싱 중 IllegalArgumentException 발생시 null인 경우 기본 메시지를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.post()
+            webTestClient.post()
                 .uri("/test-json-exceptions/validation-error")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue("""{"validField": null}""")
@@ -156,9 +156,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `직접 던진 IllegalArgumentException 발생시 400 상태코드와 예외 메시지를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.get()
+            webTestClient.get()
                 .uri("/test-argument-exceptions/illegal-argument")
                 .exchange()
                 .expectStatus().isBadRequest
@@ -175,9 +175,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `Exception 발생시 500 상태코드와 서버 오류 메시지를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.get()
+            webTestClient.get()
                 .uri("/test-generic-exceptions/runtime-exception")
                 .exchange()
                 .expectStatus().is5xxServerError
@@ -189,9 +189,9 @@ class GlobalExceptionHandlerTest : IntegrationTest() {
 
         @Test
         fun `존재하지 않는 엔드포인트 요청시 404 상태코드를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            client.get()
+            webTestClient.get()
                 .uri("/non-existent-endpoint")
                 .exchange()
                 .expectStatus().isNotFound

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/file/entrypoint/FileControllerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/file/entrypoint/FileControllerTest.kt
@@ -9,9 +9,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.client.MultipartBodyBuilder
-import org.springframework.mock.web.MockMultipartFile
-import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.reactive.function.BodyInserters
 
@@ -25,8 +22,13 @@ class FileControllerTest : IntegrationTest() {
             loginAsTemporaryMember()
 
             val testFile = FileFixture.createMockFile("test.jpg", "image/jpeg")
+            val multipartData = FileFixture.createMultipartData(testFile, FileType.PROFILE.name)
 
-            val response = uploadFile(testFile, FileType.PROFILE.name)
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isOk
@@ -44,8 +46,13 @@ class FileControllerTest : IntegrationTest() {
         fun `PNG 이미지 파일이면 파일 URL을 반환한다`() {
             loginAsTemporaryMember()
             val testFile = FileFixture.createMockFile("test.png", "image/png")
+            val multipartData = FileFixture.createMultipartData(testFile, "PROFILE")
 
-            val response = uploadFile(testFile, "PROFILE")
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isOk
@@ -69,7 +76,13 @@ class FileControllerTest : IntegrationTest() {
             loginAsTemporaryMember()
             val testFile = FileFixture.createMockFile("test.jpg", "image/jpeg")
 
-            val response = uploadFile(testFile, invalidType)
+            val multipartData = FileFixture.createMultipartData(testFile, invalidType)
+
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isBadRequest
@@ -83,7 +96,13 @@ class FileControllerTest : IntegrationTest() {
             loginAsTemporaryMember()
             val testFile = FileFixture.createMockFile("test.pdf", "application/pdf")
 
-            val response = uploadFile(testFile, "PROFILE")
+            val multipartData = FileFixture.createMultipartData(testFile, "PROFILE")
+
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isBadRequest
@@ -97,7 +116,13 @@ class FileControllerTest : IntegrationTest() {
             loginAsTemporaryMember()
             val testFile = FileFixture.createMockFile("test.txt", "text/plain")
 
-            val response = uploadFile(testFile, "PROFILE")
+            val multipartData = FileFixture.createMultipartData(testFile, "PROFILE")
+
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isBadRequest
@@ -115,7 +140,13 @@ class FileControllerTest : IntegrationTest() {
             loginAsTemporaryMember()
             val emptyFile = FileFixture.createMockFile("empty-file.jpg", "image/jpeg", size = 0)
 
-            val response = uploadFile(emptyFile, "PROFILE")
+            val multipartData = FileFixture.createMultipartData(emptyFile, "PROFILE")
+
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isBadRequest
@@ -129,7 +160,13 @@ class FileControllerTest : IntegrationTest() {
             loginAsTemporaryMember()
             val largeTestFile = FileFixture.createMockFile("large-test-file.jpg", "image/jpeg", size = 11L * 1024 * 1024)
 
-            val response = uploadFile(largeTestFile, "PROFILE")
+            val multipartData = FileFixture.createMultipartData(largeTestFile, "PROFILE")
+
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().is4xxClientError
@@ -187,26 +224,16 @@ class FileControllerTest : IntegrationTest() {
         fun `인증되지 않은 사용자면 401 에러를 반환한다`() {
             val testFile = FileFixture.createMockFile("test.jpg", "image/jpeg")
 
-            val response = uploadFile(testFile, "PROFILE")
+            val multipartData = FileFixture.createMultipartData(testFile, "PROFILE")
+
+            val response = webTestClient.post()
+                .uri("/api/v1/files")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartData))
+                .exchange()
 
             response
                 .expectStatus().isUnauthorized
         }
-    }
-    private fun uploadFile(file: MockMultipartFile, type: String): WebTestClient.ResponseSpec {
-        val bodyBuilder = MultipartBodyBuilder()
-
-        bodyBuilder.part("file", file.resource)
-            .filename(file.originalFilename)
-            .contentType(MediaType.parseMediaType(file.contentType!!))
-
-        bodyBuilder.part("type", type)
-            .contentType(MediaType.TEXT_PLAIN)
-
-        return webTestClient.post()
-            .uri("/api/v1/files")
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
-            .exchange()
     }
 }

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/member/entrypoint/NicknameValidationControllerTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/member/entrypoint/NicknameValidationControllerTest.kt
@@ -28,9 +28,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
         @Test
         fun `유효한 닉네임으로 검증 요청 시 성공 응답을 반환한다`() {
             val validNickname = "홍길동"
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -51,9 +51,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
         @Test
         fun `길이가 부족한 닉네임으로 검증 요청 시 400 에러를 반환한다`() {
             val invalidNickname = "a" // 1자 길이 위반
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -70,9 +70,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
         @Test
         fun `허용되지 않은 특수문자가 포함된 닉네임으로 검증 요청 시 400 에러를 반환한다`() {
             val invalidNickname = "홍길동@"
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -89,9 +89,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
         @Test
         fun `앞뒤 공백이 있는 닉네임으로 검증 요청 시 400 에러를 반환한다`() {
             val invalidNickname = " hello"
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -108,9 +108,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
         @Test
         fun `연속된 특수문자가 있는 닉네임으로 검증 요청 시 400 에러를 반환한다`() {
             val invalidNickname = "hello  world"
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -131,9 +131,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
         @Test
         fun `중복된 닉네임으로 검증 요청 시 400 에러를 반환한다`() {
             val duplicateNickname = "existMember" // setUp에서 생성된 기존 회원 닉네임
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
 
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -153,9 +153,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
 
         @Test
         fun `빈 닉네임으로 검증 요청 시 400 에러를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
             
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -168,9 +168,9 @@ class NicknameValidationControllerTest : IntegrationTest() {
 
         @Test
         fun `닉네임이 누락된 요청 시 400 에러를 반환한다`() {
-            val client = loginAsTemporaryMember()
+            loginAsTemporaryMember()
             
-            val response = client
+            val response = webTestClient
                 .post()
                 .uri("/api/v1/members/nickname/validate")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/IntegrationTest.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/IntegrationTest.kt
@@ -47,7 +47,7 @@ abstract class IntegrationTest {
         clock.now()
     }
 
-    fun loginAsTemporaryMember(): WebTestClient {
+    protected fun loginAsTemporaryMember() {
         val validAccessToken = "valid_kakao_access_token"
 
         KakaoApiMockServer.enqueueSuccessResponse()
@@ -62,7 +62,7 @@ abstract class IntegrationTest {
             .responseBody
             .blockFirst()!!["data"]["access_token"].asText()
 
-        return webTestClient.mutate()
+        webTestClient = webTestClient.mutate()
             .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $token")
             .build()
     }

--- a/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/fixture/FileFixture.kt
+++ b/apps/localtalk-api/src/test/kotlin/com/localtalk/api/support/fixture/FileFixture.kt
@@ -1,6 +1,10 @@
 package com.localtalk.api.support.fixture
 
+import org.springframework.http.HttpEntity
+import org.springframework.http.MediaType
+import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.mock.web.MockMultipartFile
+import org.springframework.util.MultiValueMap
 
 object FileFixture {
 
@@ -14,4 +18,20 @@ object FileFixture {
         contentType,
         ByteArray(size.toInt()),
     )
+
+    fun createMultipartData(
+        file: MockMultipartFile,
+        type: String
+    ): MultiValueMap<String, HttpEntity<*>> {
+        val bodyBuilder = MultipartBodyBuilder()
+
+        bodyBuilder.part("file", file.resource)
+            .filename(file.originalFilename)
+            .contentType(MediaType.parseMediaType(file.contentType!!))
+
+        bodyBuilder.part("type", type)
+            .contentType(MediaType.TEXT_PLAIN)
+
+        return bodyBuilder.build()
+    }
 }


### PR DESCRIPTION
## PR 설명

- [♻️ refactor : 테스트에서 인증시 인증된 클라이언트를 반환하는 것이 아닌 헤더에 자동으로 인증 헤더를 추가한 상태로 처리하도록 변경](https://github.com/local-talk/local-talk-BE/commit/35c54bae794da33e0df4f7c951a7c82be4560267) 
  - 기존에는 인증된 테스트 클라이언트를 반환하여 해당 클라이언트에서 사용하는 방식으로 구현했었음
  - 이로 인해 인증된 클라이언트(인증때 반환된 객체)와 인증되지 않은 클라이언트(IntegrationTest의 필드로 존재하는 객체) 2개가 존재해 실수하기 쉽고 불필요한 코드들이 추가됨
  - 인증시에 IntegrationTest의 WebTestClient를 덮어쓰고 테스트 실행시마다 Spring에서 WebTestClient를 초기화하여 테스트 격리성은 보장하고 실수 및 작성되는 코드양을 줄임
- [♻️ refactor : Multipart 파일 데이터를 Fixture로 분리하고 file 업로드 API 직접 호출하도록 변경](https://github.com/local-talk/local-talk-BE/commit/593d122806745ed54f689b896babff0ab9f25c9b)
  - uploadFile이라는 메서드로 업로드를 관리하고 있었으나 직접적으로 API를 호출하는 로직이 메서드안에 감춰져 있어 테스트만 봐서 정확한 동작을 확인하기 어렵다고 느꼈음
  - Multipart 요청을 위한 객체를 별도의 Fixture로 분리하고 메서드안에서 API 요청하는 것을 명시적으로 작성할 수 있도록 개선함

## 작업 내용

- [x] 테스트 인증시 별도의 클라이언트를 반환하여 복잡해지는 대신 WebClient를 새 객체로 대체하여 더 쉽게 사용할 수 있도록 변경
- [x] 각 테스트의 절차를 명확하게 하기 위해 요청 객체는 Fixture로 분리하고 API를 직접 호출하도록 변경
